### PR TITLE
Usage Documentation Updates

### DIFF
--- a/docs/requirements/v2.0.1/REQUIREMENTS.md
+++ b/docs/requirements/v2.0.1/REQUIREMENTS.md
@@ -4,207 +4,207 @@ Requirements Summary
 
 # DOI management
 
-## The software shall be capable of accepting a request to create a draft DOI. ([#5](https://github.com/NASA-PDS/pds-doi-service/issues/5)) 
+## The software shall be capable of accepting a request to create a draft DOI. ([#5](https://github.com/NASA-PDS/pds-doi-service/issues/5))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to reserve a DOI. ([#6](https://github.com/NASA-PDS/pds-doi-service/issues/6)) 
+## The software shall be capable of accepting a request to reserve a DOI. ([#6](https://github.com/NASA-PDS/pds-doi-service/issues/6))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to release a DOI. ([#7](https://github.com/NASA-PDS/pds-doi-service/issues/7)) 
+## The software shall be capable of accepting a request to release a DOI. ([#7](https://github.com/NASA-PDS/pds-doi-service/issues/7))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to deactivate a DOI. ([#8](https://github.com/NASA-PDS/pds-doi-service/issues/8)) 
+## The software shall be capable of accepting a request to deactivate a DOI. ([#8](https://github.com/NASA-PDS/pds-doi-service/issues/8))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to update DOI metadata. ([#9](https://github.com/NASA-PDS/pds-doi-service/issues/9)) 
+## The software shall be capable of accepting a request to update DOI metadata. ([#9](https://github.com/NASA-PDS/pds-doi-service/issues/9))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of batch processing >1 DOI requests.	 ([#10](https://github.com/NASA-PDS/pds-doi-service/issues/10)) 
+## The software shall be capable of batch processing >1 DOI requests.	 ([#10](https://github.com/NASA-PDS/pds-doi-service/issues/10))
 
 
 This requirement is not impacted by the current version
 # DOI metadata
 
-## The software shall be capable of autonomously generating the minimum set of DOI metadata from PDS4 Collection, Bundle, Document products. ([#11](https://github.com/NASA-PDS/pds-doi-service/issues/11)) 
+## The software shall be capable of autonomously generating the minimum set of DOI metadata from PDS4 Collection, Bundle, Document products. ([#11](https://github.com/NASA-PDS/pds-doi-service/issues/11))
 
 
 This requirement is not impacted by the current version
-## The software shall validate a minimum set of metadata is provided when reserving, releasing, or updating a DOI. This minimum set of metadata will be defined by the PDS DOI Working Group. ([#12](https://github.com/NASA-PDS/pds-doi-service/issues/12)) 
+## The software shall validate a minimum set of metadata is provided when reserving, releasing, or updating a DOI. This minimum set of metadata will be defined by the PDS DOI Working Group. ([#12](https://github.com/NASA-PDS/pds-doi-service/issues/12))
 
 
 This requirement is not impacted by the current version
-## The software shall validate the DOI metadata when reserving, releasing, or updating a DOI. ([#13](https://github.com/NASA-PDS/pds-doi-service/issues/13)) 
+## The software shall validate the DOI metadata when reserving, releasing, or updating a DOI. ([#13](https://github.com/NASA-PDS/pds-doi-service/issues/13))
 
 
 This requirement is not impacted by the current version
 #  DOI interface support
 
-## The software shall maintain a database of PDS DOIs and their current state. ([#14](https://github.com/NASA-PDS/pds-doi-service/issues/14)) 
+## The software shall maintain a database of PDS DOIs and their current state. ([#14](https://github.com/NASA-PDS/pds-doi-service/issues/14))
 
 
 This requirement is not impacted by the current version
-## The software shall maintain the ability to manage DOIs through OSTI ([#15](https://github.com/NASA-PDS/pds-doi-service/issues/15)) 
+## The software shall maintain the ability to manage DOIs through OSTI ([#15](https://github.com/NASA-PDS/pds-doi-service/issues/15))
 
 
 This requirement is not impacted by the current version
-## The software shall maintain the ability to manage DOIs through DataCite. ([#16](https://github.com/NASA-PDS/pds-doi-service/issues/16)) 
+## The software shall maintain the ability to manage DOIs through DataCite. ([#16](https://github.com/NASA-PDS/pds-doi-service/issues/16))
 
 
 This requirement is not impacted by the current version
 # DOI-management
 
-## The software shall provide a Status capability that will allow a user to query for the current status of a DOI ([#30](https://github.com/NASA-PDS/pds-doi-service/issues/30)) 
+## The software shall provide a Status capability that will allow a user to query for the current status of a DOI ([#30](https://github.com/NASA-PDS/pds-doi-service/issues/30))
 
 
 This requirement is not impacted by the current version
-## The software shall provide the capability of producing a DOI Status Report based upon a user-specified query ([#35](https://github.com/NASA-PDS/pds-doi-service/issues/35)) 
+## The software shall provide the capability of producing a DOI Status Report based upon a user-specified query ([#35](https://github.com/NASA-PDS/pds-doi-service/issues/35))
 
 
 This requirement is not impacted by the current version
 # default
 
-## As a node operator, I want to include a DOI as a related identifier in the DOI metadata for parent PDS4 products. ([#69](https://github.com/NASA-PDS/pds-doi-service/issues/69)) 
+## As a node operator, I want to include a DOI as a related identifier in the DOI metadata for parent PDS4 products. ([#69](https://github.com/NASA-PDS/pds-doi-service/issues/69))
 
 
 This requirement is not impacted by the current version
-## As a node user, I want the LIDVID associated with a DOI to be automatically updated for accumulating bundles / collections. ([#97](https://github.com/NASA-PDS/pds-doi-service/issues/97)) 
+## As a node user, I want the LIDVID associated with a DOI to be automatically updated for accumulating bundles / collections. ([#97](https://github.com/NASA-PDS/pds-doi-service/issues/97))
 
 
 This requirement is not impacted by the current version
-## As the PDS, I want to mint DOIs through DataCite ([#103](https://github.com/NASA-PDS/pds-doi-service/issues/103)) 
+## As the PDS, I want to mint DOIs through DataCite ([#103](https://github.com/NASA-PDS/pds-doi-service/issues/103))
 
 
 This requirement is not impacted by the current version
-## Develop DOI Service - Registry integration component for accumulating bundles ([#111](https://github.com/NASA-PDS/pds-doi-service/issues/111)) 
+## Develop DOI Service - Registry integration component for accumulating bundles ([#111](https://github.com/NASA-PDS/pds-doi-service/issues/111))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to see the lidvid of my DOIs in the email report ([#167](https://github.com/NASA-PDS/pds-doi-service/issues/167)) 
+## As a user, I want to see the lidvid of my DOIs in the email report ([#167](https://github.com/NASA-PDS/pds-doi-service/issues/167))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to reserve a DOI through DataCite ([#171](https://github.com/NASA-PDS/pds-doi-service/issues/171)) 
+## As an operator, I want to reserve a DOI through DataCite ([#171](https://github.com/NASA-PDS/pds-doi-service/issues/171))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want query for one or more minted DOIs from DataCite ([#172](https://github.com/NASA-PDS/pds-doi-service/issues/172)) 
+## As an operator, I want query for one or more minted DOIs from DataCite ([#172](https://github.com/NASA-PDS/pds-doi-service/issues/172))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to query for a DOI's change history through DataCite ([#173](https://github.com/NASA-PDS/pds-doi-service/issues/173)) 
+## As an operator, I want to query for a DOI's change history through DataCite ([#173](https://github.com/NASA-PDS/pds-doi-service/issues/173))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to release a DOI through DataCite ([#174](https://github.com/NASA-PDS/pds-doi-service/issues/174)) 
+## As an operator, I want to release a DOI through DataCite ([#174](https://github.com/NASA-PDS/pds-doi-service/issues/174))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to update DOI metadata through DataCite ([#175](https://github.com/NASA-PDS/pds-doi-service/issues/175)) 
+## As an operator, I want to update DOI metadata through DataCite ([#175](https://github.com/NASA-PDS/pds-doi-service/issues/175))
 
 
 This requirement is not impacted by the current version
-## As an API user, I want to have pagination that is consistent with the PDS API. ([#176](https://github.com/NASA-PDS/pds-doi-service/issues/176)) 
+## As an API user, I want to have pagination that is consistent with the PDS API. ([#176](https://github.com/NASA-PDS/pds-doi-service/issues/176))
 
 
 This requirement is not impacted by the current version
-## As an API user I want to filter on lidvids with wildcards ([#177](https://github.com/NASA-PDS/pds-doi-service/issues/177)) 
+## As an API user I want to filter on lidvids with wildcards ([#177](https://github.com/NASA-PDS/pds-doi-service/issues/177))
 
 
 This requirement is not impacted by the current version
-## As an API user I want to filter on PDS3 Data Set IDs with wildcards ([#180](https://github.com/NASA-PDS/pds-doi-service/issues/180)) 
+## As an API user I want to filter on PDS3 Data Set IDs with wildcards ([#180](https://github.com/NASA-PDS/pds-doi-service/issues/180))
 
 
 This requirement is not impacted by the current version
-## As a user of the API, I want to see the DOI's title when I go GET /dois request ([#183](https://github.com/NASA-PDS/pds-doi-service/issues/183)) 
+## As a user of the API, I want to see the DOI's title when I go GET /dois request ([#183](https://github.com/NASA-PDS/pds-doi-service/issues/183))
 
 
 This requirement is not impacted by the current version
-## As an API user, I want to always have an update date for the DOIs ([#184](https://github.com/NASA-PDS/pds-doi-service/issues/184)) 
+## As an API user, I want to always have an update date for the DOIs ([#184](https://github.com/NASA-PDS/pds-doi-service/issues/184))
 
 
 This requirement is not impacted by the current version
-## As a SA, I want the operational deployment of the service to be secure ([#187](https://github.com/NASA-PDS/pds-doi-service/issues/187)) 
+## As a SA, I want the operational deployment of the service to be secure ([#187](https://github.com/NASA-PDS/pds-doi-service/issues/187))
 
 
 This requirement is not impacted by the current version
-## As a user, I want the application to support the history of PDS's DOIs, especially the one created for PDS3 products ([#192](https://github.com/NASA-PDS/pds-doi-service/issues/192)) 
+## As a user, I want the application to support the history of PDS's DOIs, especially the one created for PDS3 products ([#192](https://github.com/NASA-PDS/pds-doi-service/issues/192))
 
 
 This requirement is not impacted by the current version
-## As a system administrator, I want to be able to deploy pds_doi_service with python 3.6 ([#197](https://github.com/NASA-PDS/pds-doi-service/issues/197)) 
+## As a system administrator, I want to be able to deploy pds_doi_service with python 3.6 ([#197](https://github.com/NASA-PDS/pds-doi-service/issues/197))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to use the API with ids containing a slash (/) ([#198](https://github.com/NASA-PDS/pds-doi-service/issues/198)) 
+## As a user, I want to use the API with ids containing a slash (/) ([#198](https://github.com/NASA-PDS/pds-doi-service/issues/198))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to know what version of the software I am running ([#200](https://github.com/NASA-PDS/pds-doi-service/issues/200)) 
+## As an operator, I want to know what version of the software I am running ([#200](https://github.com/NASA-PDS/pds-doi-service/issues/200))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to know how to deploy and use the API from the Sphinx documentation ([#201](https://github.com/NASA-PDS/pds-doi-service/issues/201)) 
+## As an operator, I want to know how to deploy and use the API from the Sphinx documentation ([#201](https://github.com/NASA-PDS/pds-doi-service/issues/201))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want one place to go for all DOI Service / API / UI documentation ([#202](https://github.com/NASA-PDS/pds-doi-service/issues/202)) 
+## As an operator, I want one place to go for all DOI Service / API / UI documentation ([#202](https://github.com/NASA-PDS/pds-doi-service/issues/202))
 
 
 This requirement is not impacted by the current version
-## As a user of the command line, I don't want to see all the log info in the stdout ([#206](https://github.com/NASA-PDS/pds-doi-service/issues/206)) 
+## As a user of the command line, I don't want to see all the log info in the stdout ([#206](https://github.com/NASA-PDS/pds-doi-service/issues/206))
 
 
 This requirement is not impacted by the current version
-## As a command-line user, I want to be suggested to use -f option when a Warning exception is raised ([#207](https://github.com/NASA-PDS/pds-doi-service/issues/207)) 
+## As a command-line user, I want to be suggested to use -f option when a Warning exception is raised ([#207](https://github.com/NASA-PDS/pds-doi-service/issues/207))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to run the commandline on windows ([#212](https://github.com/NASA-PDS/pds-doi-service/issues/212)) 
+## As a user, I want to run the commandline on windows ([#212](https://github.com/NASA-PDS/pds-doi-service/issues/212))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to search dois without case sensitiveness ([#223](https://github.com/NASA-PDS/pds-doi-service/issues/223)) 
+## As a user, I want to search dois without case sensitiveness ([#223](https://github.com/NASA-PDS/pds-doi-service/issues/223))
 
 
 This requirement is not impacted by the current version
-## As a user, I would like to include licensing information with all PDS DOIs ([#224](https://github.com/NASA-PDS/pds-doi-service/issues/224)) 
+## As a user, I would like to include licensing information with all PDS DOIs ([#224](https://github.com/NASA-PDS/pds-doi-service/issues/224))
 
 
 This requirement is not impacted by the current version
-## As an admistrator of the application,  I want to restrict access to API by specific referrer ([#228](https://github.com/NASA-PDS/pds-doi-service/issues/228)) 
+## As an admistrator of the application,  I want to restrict access to API by specific referrer ([#228](https://github.com/NASA-PDS/pds-doi-service/issues/228))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to include related DOIs in DOI metadata ([#232](https://github.com/NASA-PDS/pds-doi-service/issues/232)) 
+## As a user, I want to include related DOIs in DOI metadata ([#232](https://github.com/NASA-PDS/pds-doi-service/issues/232))
 
 
 This requirement is not impacted by the current version
-## As a PDS Operator, I want to perform a bulk update of a specific field across many DOI records ([#257](https://github.com/NASA-PDS/pds-doi-service/issues/257)) 
+## As a PDS Operator, I want to perform a bulk update of a specific field across many DOI records ([#257](https://github.com/NASA-PDS/pds-doi-service/issues/257))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to search for ids without case sensitiviy ([#271](https://github.com/NASA-PDS/pds-doi-service/issues/271)) 
+## As a user, I want to search for ids without case sensitiviy ([#271](https://github.com/NASA-PDS/pds-doi-service/issues/271))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to update the LIDVID associated with a DOI  ([#278](https://github.com/NASA-PDS/pds-doi-service/issues/278)) 
+## As a user, I want to update the LIDVID associated with a DOI  ([#278](https://github.com/NASA-PDS/pds-doi-service/issues/278))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to update the bundle/collection metadata associated with a DOI for accumulating data sets ([#279](https://github.com/NASA-PDS/pds-doi-service/issues/279)) 
+## As a user, I want to update the bundle/collection metadata associated with a DOI for accumulating data sets ([#279](https://github.com/NASA-PDS/pds-doi-service/issues/279))
 
 
 This requirement is not impacted by the current version
-## As an API user, I want to know the status value which can be expected ([#280](https://github.com/NASA-PDS/pds-doi-service/issues/280)) 
+## As an API user, I want to know the status value which can be expected ([#280](https://github.com/NASA-PDS/pds-doi-service/issues/280))
 
 
 This requirement is not impacted by the current version
-## As a user, I want a simplified DOI lifecycle workflow ([#286](https://github.com/NASA-PDS/pds-doi-service/issues/286)) 
+## As a user, I want a simplified DOI lifecycle workflow ([#286](https://github.com/NASA-PDS/pds-doi-service/issues/286))
 
 
 This requirement is not impacted by the current version

--- a/docs/requirements/v2.1.0/REQUIREMENTS.md
+++ b/docs/requirements/v2.1.0/REQUIREMENTS.md
@@ -4,51 +4,51 @@ Requirements Summary
 
 # DOI management
 
-## The software shall be capable of accepting a request to create a draft DOI. ([#5](https://github.com/NASA-PDS/pds-doi-service/issues/5)) 
+## The software shall be capable of accepting a request to create a draft DOI. ([#5](https://github.com/NASA-PDS/pds-doi-service/issues/5))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to reserve a DOI. ([#6](https://github.com/NASA-PDS/pds-doi-service/issues/6)) 
+## The software shall be capable of accepting a request to reserve a DOI. ([#6](https://github.com/NASA-PDS/pds-doi-service/issues/6))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to release a DOI. ([#7](https://github.com/NASA-PDS/pds-doi-service/issues/7)) 
+## The software shall be capable of accepting a request to release a DOI. ([#7](https://github.com/NASA-PDS/pds-doi-service/issues/7))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to deactivate a DOI. ([#8](https://github.com/NASA-PDS/pds-doi-service/issues/8)) 
+## The software shall be capable of accepting a request to deactivate a DOI. ([#8](https://github.com/NASA-PDS/pds-doi-service/issues/8))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to update DOI metadata. ([#9](https://github.com/NASA-PDS/pds-doi-service/issues/9)) 
+## The software shall be capable of accepting a request to update DOI metadata. ([#9](https://github.com/NASA-PDS/pds-doi-service/issues/9))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of batch processing >1 DOI requests.	 ([#10](https://github.com/NASA-PDS/pds-doi-service/issues/10)) 
+## The software shall be capable of batch processing >1 DOI requests.	 ([#10](https://github.com/NASA-PDS/pds-doi-service/issues/10))
 
 
 This requirement is not impacted by the current version
 # DOI metadata
 
-## The software shall be capable of autonomously generating the minimum set of DOI metadata from PDS4 Collection, Bundle, Document products. ([#11](https://github.com/NASA-PDS/pds-doi-service/issues/11)) 
+## The software shall be capable of autonomously generating the minimum set of DOI metadata from PDS4 Collection, Bundle, Document products. ([#11](https://github.com/NASA-PDS/pds-doi-service/issues/11))
 
 
 This requirement is not impacted by the current version
-## The software shall validate a minimum set of metadata is provided when reserving, releasing, or updating a DOI. This minimum set of metadata will be defined by the PDS DOI Working Group. ([#12](https://github.com/NASA-PDS/pds-doi-service/issues/12)) 
+## The software shall validate a minimum set of metadata is provided when reserving, releasing, or updating a DOI. This minimum set of metadata will be defined by the PDS DOI Working Group. ([#12](https://github.com/NASA-PDS/pds-doi-service/issues/12))
 
 
 This requirement is not impacted by the current version
-## The software shall validate the DOI metadata when reserving, releasing, or updating a DOI. ([#13](https://github.com/NASA-PDS/pds-doi-service/issues/13)) 
+## The software shall validate the DOI metadata when reserving, releasing, or updating a DOI. ([#13](https://github.com/NASA-PDS/pds-doi-service/issues/13))
 
 
 This requirement is not impacted by the current version
 #  DOI interface support
 
-## The software shall maintain a database of PDS DOIs and their current state. ([#14](https://github.com/NASA-PDS/pds-doi-service/issues/14)) 
+## The software shall maintain a database of PDS DOIs and their current state. ([#14](https://github.com/NASA-PDS/pds-doi-service/issues/14))
 
 
 This requirement is not impacted by the current version
-## The software shall maintain the ability to manage DOIs through OSTI ([#15](https://github.com/NASA-PDS/pds-doi-service/issues/15)) 
+## The software shall maintain the ability to manage DOIs through OSTI ([#15](https://github.com/NASA-PDS/pds-doi-service/issues/15))
 
 
 This requirement is not impacted by the current version
@@ -60,161 +60,161 @@ The enhancements which impact this requirements are:
 
 # DOI-management
 
-## The software shall provide a Status capability that will allow a user to query for the current status of a DOI ([#30](https://github.com/NASA-PDS/pds-doi-service/issues/30)) 
+## The software shall provide a Status capability that will allow a user to query for the current status of a DOI ([#30](https://github.com/NASA-PDS/pds-doi-service/issues/30))
 
 
 This requirement is not impacted by the current version
-## The software shall provide the capability of producing a DOI Status Report based upon a user-specified query ([#35](https://github.com/NASA-PDS/pds-doi-service/issues/35)) 
+## The software shall provide the capability of producing a DOI Status Report based upon a user-specified query ([#35](https://github.com/NASA-PDS/pds-doi-service/issues/35))
 
 
 This requirement is not impacted by the current version
 # default
 
-## As a node operator, I want to include a DOI as a related identifier in the DOI metadata for parent PDS4 products. ([#69](https://github.com/NASA-PDS/pds-doi-service/issues/69)) 
+## As a node operator, I want to include a DOI as a related identifier in the DOI metadata for parent PDS4 products. ([#69](https://github.com/NASA-PDS/pds-doi-service/issues/69))
 
 
 This requirement is not impacted by the current version
-## As a node user, I want the LIDVID associated with a DOI to be automatically updated for accumulating bundles / collections. ([#97](https://github.com/NASA-PDS/pds-doi-service/issues/97)) 
+## As a node user, I want the LIDVID associated with a DOI to be automatically updated for accumulating bundles / collections. ([#97](https://github.com/NASA-PDS/pds-doi-service/issues/97))
 
 
 This requirement is not impacted by the current version
-## As the PDS, I want to mint DOIs through DataCite ([#103](https://github.com/NASA-PDS/pds-doi-service/issues/103)) 
+## As the PDS, I want to mint DOIs through DataCite ([#103](https://github.com/NASA-PDS/pds-doi-service/issues/103))
 
 
 This requirement is not impacted by the current version
-## Develop DOI Service - Registry integration component for accumulating bundles ([#111](https://github.com/NASA-PDS/pds-doi-service/issues/111)) 
+## Develop DOI Service - Registry integration component for accumulating bundles ([#111](https://github.com/NASA-PDS/pds-doi-service/issues/111))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to see the lidvid of my DOIs in the email report ([#167](https://github.com/NASA-PDS/pds-doi-service/issues/167)) 
+## As a user, I want to see the lidvid of my DOIs in the email report ([#167](https://github.com/NASA-PDS/pds-doi-service/issues/167))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to reserve a DOI through DataCite ([#171](https://github.com/NASA-PDS/pds-doi-service/issues/171)) 
+## As an operator, I want to reserve a DOI through DataCite ([#171](https://github.com/NASA-PDS/pds-doi-service/issues/171))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want query for one or more minted DOIs from DataCite ([#172](https://github.com/NASA-PDS/pds-doi-service/issues/172)) 
+## As an operator, I want query for one or more minted DOIs from DataCite ([#172](https://github.com/NASA-PDS/pds-doi-service/issues/172))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to query for a DOI's change history through DataCite ([#173](https://github.com/NASA-PDS/pds-doi-service/issues/173)) 
+## As an operator, I want to query for a DOI's change history through DataCite ([#173](https://github.com/NASA-PDS/pds-doi-service/issues/173))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to release a DOI through DataCite ([#174](https://github.com/NASA-PDS/pds-doi-service/issues/174)) 
+## As an operator, I want to release a DOI through DataCite ([#174](https://github.com/NASA-PDS/pds-doi-service/issues/174))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to update DOI metadata through DataCite ([#175](https://github.com/NASA-PDS/pds-doi-service/issues/175)) 
+## As an operator, I want to update DOI metadata through DataCite ([#175](https://github.com/NASA-PDS/pds-doi-service/issues/175))
 
 
 This requirement is not impacted by the current version
-## As an API user, I want to have pagination that is consistent with the PDS API. ([#176](https://github.com/NASA-PDS/pds-doi-service/issues/176)) 
+## As an API user, I want to have pagination that is consistent with the PDS API. ([#176](https://github.com/NASA-PDS/pds-doi-service/issues/176))
 
 
 This requirement is not impacted by the current version
-## As an API user I want to filter on lidvids with wildcards ([#177](https://github.com/NASA-PDS/pds-doi-service/issues/177)) 
+## As an API user I want to filter on lidvids with wildcards ([#177](https://github.com/NASA-PDS/pds-doi-service/issues/177))
 
 
 This requirement is not impacted by the current version
-## As an API user I want to filter on PDS3 Data Set IDs with wildcards ([#180](https://github.com/NASA-PDS/pds-doi-service/issues/180)) 
+## As an API user I want to filter on PDS3 Data Set IDs with wildcards ([#180](https://github.com/NASA-PDS/pds-doi-service/issues/180))
 
 
 This requirement is not impacted by the current version
-## As a user of the API, I want to see the DOI's title when I go GET /dois request ([#183](https://github.com/NASA-PDS/pds-doi-service/issues/183)) 
+## As a user of the API, I want to see the DOI's title when I go GET /dois request ([#183](https://github.com/NASA-PDS/pds-doi-service/issues/183))
 
 
 This requirement is not impacted by the current version
-## As an API user, I want to always have an update date for the DOIs ([#184](https://github.com/NASA-PDS/pds-doi-service/issues/184)) 
+## As an API user, I want to always have an update date for the DOIs ([#184](https://github.com/NASA-PDS/pds-doi-service/issues/184))
 
 
 This requirement is not impacted by the current version
-## As a SA, I want the operational deployment of the service to be secure ([#187](https://github.com/NASA-PDS/pds-doi-service/issues/187)) 
+## As a SA, I want the operational deployment of the service to be secure ([#187](https://github.com/NASA-PDS/pds-doi-service/issues/187))
 
 
 This requirement is not impacted by the current version
-## As a user, I want the application to support the history of PDS's DOIs, especially the one created for PDS3 products ([#192](https://github.com/NASA-PDS/pds-doi-service/issues/192)) 
+## As a user, I want the application to support the history of PDS's DOIs, especially the one created for PDS3 products ([#192](https://github.com/NASA-PDS/pds-doi-service/issues/192))
 
 
 This requirement is not impacted by the current version
-## As a system administrator, I want to be able to deploy pds_doi_service with python 3.6 ([#197](https://github.com/NASA-PDS/pds-doi-service/issues/197)) 
+## As a system administrator, I want to be able to deploy pds_doi_service with python 3.6 ([#197](https://github.com/NASA-PDS/pds-doi-service/issues/197))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to use the API with ids containing a slash (/) ([#198](https://github.com/NASA-PDS/pds-doi-service/issues/198)) 
+## As a user, I want to use the API with ids containing a slash (/) ([#198](https://github.com/NASA-PDS/pds-doi-service/issues/198))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to know what version of the software I am running ([#200](https://github.com/NASA-PDS/pds-doi-service/issues/200)) 
+## As an operator, I want to know what version of the software I am running ([#200](https://github.com/NASA-PDS/pds-doi-service/issues/200))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to know how to deploy and use the API from the Sphinx documentation ([#201](https://github.com/NASA-PDS/pds-doi-service/issues/201)) 
+## As an operator, I want to know how to deploy and use the API from the Sphinx documentation ([#201](https://github.com/NASA-PDS/pds-doi-service/issues/201))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want one place to go for all DOI Service / API / UI documentation ([#202](https://github.com/NASA-PDS/pds-doi-service/issues/202)) 
+## As an operator, I want one place to go for all DOI Service / API / UI documentation ([#202](https://github.com/NASA-PDS/pds-doi-service/issues/202))
 
 
 This requirement is not impacted by the current version
-## As a user of the command line, I don't want to see all the log info in the stdout ([#206](https://github.com/NASA-PDS/pds-doi-service/issues/206)) 
+## As a user of the command line, I don't want to see all the log info in the stdout ([#206](https://github.com/NASA-PDS/pds-doi-service/issues/206))
 
 
 This requirement is not impacted by the current version
-## As a command-line user, I want to be suggested to use -f option when a Warning exception is raised ([#207](https://github.com/NASA-PDS/pds-doi-service/issues/207)) 
+## As a command-line user, I want to be suggested to use -f option when a Warning exception is raised ([#207](https://github.com/NASA-PDS/pds-doi-service/issues/207))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to run the commandline on windows ([#212](https://github.com/NASA-PDS/pds-doi-service/issues/212)) 
+## As a user, I want to run the commandline on windows ([#212](https://github.com/NASA-PDS/pds-doi-service/issues/212))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to search dois without case sensitiveness ([#223](https://github.com/NASA-PDS/pds-doi-service/issues/223)) 
+## As a user, I want to search dois without case sensitiveness ([#223](https://github.com/NASA-PDS/pds-doi-service/issues/223))
 
 
 This requirement is not impacted by the current version
-## As a user, I would like to include licensing information with all PDS DOIs ([#224](https://github.com/NASA-PDS/pds-doi-service/issues/224)) 
+## As a user, I would like to include licensing information with all PDS DOIs ([#224](https://github.com/NASA-PDS/pds-doi-service/issues/224))
 
 
 This requirement is not impacted by the current version
-## As an admistrator of the application,  I want to restrict access to API by specific referrer ([#228](https://github.com/NASA-PDS/pds-doi-service/issues/228)) 
+## As an admistrator of the application,  I want to restrict access to API by specific referrer ([#228](https://github.com/NASA-PDS/pds-doi-service/issues/228))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to include related DOIs in DOI metadata ([#232](https://github.com/NASA-PDS/pds-doi-service/issues/232)) 
+## As a user, I want to include related DOIs in DOI metadata ([#232](https://github.com/NASA-PDS/pds-doi-service/issues/232))
 
 
 This requirement is not impacted by the current version
-## As a PDS Operator, I want to perform a bulk update of a specific field across many DOI records ([#257](https://github.com/NASA-PDS/pds-doi-service/issues/257)) 
+## As a PDS Operator, I want to perform a bulk update of a specific field across many DOI records ([#257](https://github.com/NASA-PDS/pds-doi-service/issues/257))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to search for ids without case sensitiviy ([#271](https://github.com/NASA-PDS/pds-doi-service/issues/271)) 
+## As a user, I want to search for ids without case sensitiviy ([#271](https://github.com/NASA-PDS/pds-doi-service/issues/271))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to update the LIDVID associated with a DOI  ([#278](https://github.com/NASA-PDS/pds-doi-service/issues/278)) 
+## As a user, I want to update the LIDVID associated with a DOI  ([#278](https://github.com/NASA-PDS/pds-doi-service/issues/278))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to update the bundle/collection metadata associated with a DOI for accumulating data sets ([#279](https://github.com/NASA-PDS/pds-doi-service/issues/279)) 
+## As a user, I want to update the bundle/collection metadata associated with a DOI for accumulating data sets ([#279](https://github.com/NASA-PDS/pds-doi-service/issues/279))
 
 
 This requirement is not impacted by the current version
-## As an API user, I want to know the status value which can be expected ([#280](https://github.com/NASA-PDS/pds-doi-service/issues/280)) 
+## As an API user, I want to know the status value which can be expected ([#280](https://github.com/NASA-PDS/pds-doi-service/issues/280))
 
 
 This requirement is not impacted by the current version
-## As a user, I want a simplified DOI lifecycle workflow ([#286](https://github.com/NASA-PDS/pds-doi-service/issues/286)) 
+## As a user, I want a simplified DOI lifecycle workflow ([#286](https://github.com/NASA-PDS/pds-doi-service/issues/286))
 
 
 This requirement is not impacted by the current version
-## Update default values to sync with SBN documentation ([#295](https://github.com/NASA-PDS/pds-doi-service/issues/295)) 
+## Update default values to sync with SBN documentation ([#295](https://github.com/NASA-PDS/pds-doi-service/issues/295))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to sort by DOI, title, or identifier. ([#306](https://github.com/NASA-PDS/pds-doi-service/issues/306)) 
+## As a user, I want to sort by DOI, title, or identifier. ([#306](https://github.com/NASA-PDS/pds-doi-service/issues/306))
 
 
 This requirement is not impacted by the current version

--- a/docs/requirements/v2.1.1-dev/REQUIREMENTS.md
+++ b/docs/requirements/v2.1.1-dev/REQUIREMENTS.md
@@ -4,211 +4,211 @@ Requirements Summary
 
 # DOI management
 
-## The software shall be capable of accepting a request to create a draft DOI. ([#5](https://github.com/NASA-PDS/pds-doi-service/issues/5)) 
+## The software shall be capable of accepting a request to create a draft DOI. ([#5](https://github.com/NASA-PDS/pds-doi-service/issues/5))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to reserve a DOI. ([#6](https://github.com/NASA-PDS/pds-doi-service/issues/6)) 
+## The software shall be capable of accepting a request to reserve a DOI. ([#6](https://github.com/NASA-PDS/pds-doi-service/issues/6))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to release a DOI. ([#7](https://github.com/NASA-PDS/pds-doi-service/issues/7)) 
+## The software shall be capable of accepting a request to release a DOI. ([#7](https://github.com/NASA-PDS/pds-doi-service/issues/7))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to deactivate a DOI. ([#8](https://github.com/NASA-PDS/pds-doi-service/issues/8)) 
+## The software shall be capable of accepting a request to deactivate a DOI. ([#8](https://github.com/NASA-PDS/pds-doi-service/issues/8))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to update DOI metadata. ([#9](https://github.com/NASA-PDS/pds-doi-service/issues/9)) 
+## The software shall be capable of accepting a request to update DOI metadata. ([#9](https://github.com/NASA-PDS/pds-doi-service/issues/9))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of batch processing >1 DOI requests.	 ([#10](https://github.com/NASA-PDS/pds-doi-service/issues/10)) 
+## The software shall be capable of batch processing >1 DOI requests.	 ([#10](https://github.com/NASA-PDS/pds-doi-service/issues/10))
 
 
 This requirement is not impacted by the current version
 # DOI metadata
 
-## The software shall be capable of autonomously generating the minimum set of DOI metadata from PDS4 Collection, Bundle, Document products. ([#11](https://github.com/NASA-PDS/pds-doi-service/issues/11)) 
+## The software shall be capable of autonomously generating the minimum set of DOI metadata from PDS4 Collection, Bundle, Document products. ([#11](https://github.com/NASA-PDS/pds-doi-service/issues/11))
 
 
 This requirement is not impacted by the current version
-## The software shall validate a minimum set of metadata is provided when reserving, releasing, or updating a DOI. This minimum set of metadata will be defined by the PDS DOI Working Group. ([#12](https://github.com/NASA-PDS/pds-doi-service/issues/12)) 
+## The software shall validate a minimum set of metadata is provided when reserving, releasing, or updating a DOI. This minimum set of metadata will be defined by the PDS DOI Working Group. ([#12](https://github.com/NASA-PDS/pds-doi-service/issues/12))
 
 
 This requirement is not impacted by the current version
-## The software shall validate the DOI metadata when reserving, releasing, or updating a DOI. ([#13](https://github.com/NASA-PDS/pds-doi-service/issues/13)) 
+## The software shall validate the DOI metadata when reserving, releasing, or updating a DOI. ([#13](https://github.com/NASA-PDS/pds-doi-service/issues/13))
 
 
 This requirement is not impacted by the current version
 #  DOI interface support
 
-## The software shall maintain a database of PDS DOIs and their current state. ([#14](https://github.com/NASA-PDS/pds-doi-service/issues/14)) 
+## The software shall maintain a database of PDS DOIs and their current state. ([#14](https://github.com/NASA-PDS/pds-doi-service/issues/14))
 
 
 This requirement is not impacted by the current version
-## The software shall maintain the ability to manage DOIs through OSTI ([#15](https://github.com/NASA-PDS/pds-doi-service/issues/15)) 
+## The software shall maintain the ability to manage DOIs through OSTI ([#15](https://github.com/NASA-PDS/pds-doi-service/issues/15))
 
 
 This requirement is not impacted by the current version
-## The software shall maintain the ability to manage DOIs through DataCite. ([#16](https://github.com/NASA-PDS/pds-doi-service/issues/16)) 
+## The software shall maintain the ability to manage DOIs through DataCite. ([#16](https://github.com/NASA-PDS/pds-doi-service/issues/16))
 
 
 This requirement is not impacted by the current version
 # DOI-management
 
-## The software shall provide a Status capability that will allow a user to query for the current status of a DOI ([#30](https://github.com/NASA-PDS/pds-doi-service/issues/30)) 
+## The software shall provide a Status capability that will allow a user to query for the current status of a DOI ([#30](https://github.com/NASA-PDS/pds-doi-service/issues/30))
 
 
 This requirement is not impacted by the current version
-## The software shall provide the capability of producing a DOI Status Report based upon a user-specified query ([#35](https://github.com/NASA-PDS/pds-doi-service/issues/35)) 
+## The software shall provide the capability of producing a DOI Status Report based upon a user-specified query ([#35](https://github.com/NASA-PDS/pds-doi-service/issues/35))
 
 
 This requirement is not impacted by the current version
 # default
 
-## As a node operator, I want to include a DOI as a related identifier in the DOI metadata for parent PDS4 products. ([#69](https://github.com/NASA-PDS/pds-doi-service/issues/69)) 
+## As a node operator, I want to include a DOI as a related identifier in the DOI metadata for parent PDS4 products. ([#69](https://github.com/NASA-PDS/pds-doi-service/issues/69))
 
 
 This requirement is not impacted by the current version
-## As a node user, I want the LIDVID associated with a DOI to be automatically updated for accumulating bundles / collections. ([#97](https://github.com/NASA-PDS/pds-doi-service/issues/97)) 
+## As a node user, I want the LIDVID associated with a DOI to be automatically updated for accumulating bundles / collections. ([#97](https://github.com/NASA-PDS/pds-doi-service/issues/97))
 
 
 This requirement is not impacted by the current version
-## As the PDS, I want to mint DOIs through DataCite ([#103](https://github.com/NASA-PDS/pds-doi-service/issues/103)) 
+## As the PDS, I want to mint DOIs through DataCite ([#103](https://github.com/NASA-PDS/pds-doi-service/issues/103))
 
 
 This requirement is not impacted by the current version
-## Develop DOI Service - Registry integration component for accumulating bundles ([#111](https://github.com/NASA-PDS/pds-doi-service/issues/111)) 
+## Develop DOI Service - Registry integration component for accumulating bundles ([#111](https://github.com/NASA-PDS/pds-doi-service/issues/111))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to see the lidvid of my DOIs in the email report ([#167](https://github.com/NASA-PDS/pds-doi-service/issues/167)) 
+## As a user, I want to see the lidvid of my DOIs in the email report ([#167](https://github.com/NASA-PDS/pds-doi-service/issues/167))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to reserve a DOI through DataCite ([#171](https://github.com/NASA-PDS/pds-doi-service/issues/171)) 
+## As an operator, I want to reserve a DOI through DataCite ([#171](https://github.com/NASA-PDS/pds-doi-service/issues/171))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want query for one or more minted DOIs from DataCite ([#172](https://github.com/NASA-PDS/pds-doi-service/issues/172)) 
+## As an operator, I want query for one or more minted DOIs from DataCite ([#172](https://github.com/NASA-PDS/pds-doi-service/issues/172))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to query for a DOI's change history through DataCite ([#173](https://github.com/NASA-PDS/pds-doi-service/issues/173)) 
+## As an operator, I want to query for a DOI's change history through DataCite ([#173](https://github.com/NASA-PDS/pds-doi-service/issues/173))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to release a DOI through DataCite ([#174](https://github.com/NASA-PDS/pds-doi-service/issues/174)) 
+## As an operator, I want to release a DOI through DataCite ([#174](https://github.com/NASA-PDS/pds-doi-service/issues/174))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to update DOI metadata through DataCite ([#175](https://github.com/NASA-PDS/pds-doi-service/issues/175)) 
+## As an operator, I want to update DOI metadata through DataCite ([#175](https://github.com/NASA-PDS/pds-doi-service/issues/175))
 
 
 This requirement is not impacted by the current version
-## As an API user, I want to have pagination that is consistent with the PDS API. ([#176](https://github.com/NASA-PDS/pds-doi-service/issues/176)) 
+## As an API user, I want to have pagination that is consistent with the PDS API. ([#176](https://github.com/NASA-PDS/pds-doi-service/issues/176))
 
 
 This requirement is not impacted by the current version
-## As an API user I want to filter on lidvids with wildcards ([#177](https://github.com/NASA-PDS/pds-doi-service/issues/177)) 
+## As an API user I want to filter on lidvids with wildcards ([#177](https://github.com/NASA-PDS/pds-doi-service/issues/177))
 
 
 This requirement is not impacted by the current version
-## As an API user I want to filter on PDS3 Data Set IDs with wildcards ([#180](https://github.com/NASA-PDS/pds-doi-service/issues/180)) 
+## As an API user I want to filter on PDS3 Data Set IDs with wildcards ([#180](https://github.com/NASA-PDS/pds-doi-service/issues/180))
 
 
 This requirement is not impacted by the current version
-## As a user of the API, I want to see the DOI's title when I go GET /dois request ([#183](https://github.com/NASA-PDS/pds-doi-service/issues/183)) 
+## As a user of the API, I want to see the DOI's title when I go GET /dois request ([#183](https://github.com/NASA-PDS/pds-doi-service/issues/183))
 
 
 This requirement is not impacted by the current version
-## As an API user, I want to always have an update date for the DOIs ([#184](https://github.com/NASA-PDS/pds-doi-service/issues/184)) 
+## As an API user, I want to always have an update date for the DOIs ([#184](https://github.com/NASA-PDS/pds-doi-service/issues/184))
 
 
 This requirement is not impacted by the current version
-## As a SA, I want the operational deployment of the service to be secure ([#187](https://github.com/NASA-PDS/pds-doi-service/issues/187)) 
+## As a SA, I want the operational deployment of the service to be secure ([#187](https://github.com/NASA-PDS/pds-doi-service/issues/187))
 
 
 This requirement is not impacted by the current version
-## As a user, I want the application to support the history of PDS's DOIs, especially the one created for PDS3 products ([#192](https://github.com/NASA-PDS/pds-doi-service/issues/192)) 
+## As a user, I want the application to support the history of PDS's DOIs, especially the one created for PDS3 products ([#192](https://github.com/NASA-PDS/pds-doi-service/issues/192))
 
 
 This requirement is not impacted by the current version
-## As a system administrator, I want to be able to deploy pds_doi_service with python 3.6 ([#197](https://github.com/NASA-PDS/pds-doi-service/issues/197)) 
+## As a system administrator, I want to be able to deploy pds_doi_service with python 3.6 ([#197](https://github.com/NASA-PDS/pds-doi-service/issues/197))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to use the API with ids containing a slash (/) ([#198](https://github.com/NASA-PDS/pds-doi-service/issues/198)) 
+## As a user, I want to use the API with ids containing a slash (/) ([#198](https://github.com/NASA-PDS/pds-doi-service/issues/198))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to know what version of the software I am running ([#200](https://github.com/NASA-PDS/pds-doi-service/issues/200)) 
+## As an operator, I want to know what version of the software I am running ([#200](https://github.com/NASA-PDS/pds-doi-service/issues/200))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to know how to deploy and use the API from the Sphinx documentation ([#201](https://github.com/NASA-PDS/pds-doi-service/issues/201)) 
+## As an operator, I want to know how to deploy and use the API from the Sphinx documentation ([#201](https://github.com/NASA-PDS/pds-doi-service/issues/201))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want one place to go for all DOI Service / API / UI documentation ([#202](https://github.com/NASA-PDS/pds-doi-service/issues/202)) 
+## As an operator, I want one place to go for all DOI Service / API / UI documentation ([#202](https://github.com/NASA-PDS/pds-doi-service/issues/202))
 
 
 This requirement is not impacted by the current version
-## As a user of the command line, I don't want to see all the log info in the stdout ([#206](https://github.com/NASA-PDS/pds-doi-service/issues/206)) 
+## As a user of the command line, I don't want to see all the log info in the stdout ([#206](https://github.com/NASA-PDS/pds-doi-service/issues/206))
 
 
 This requirement is not impacted by the current version
-## As a command-line user, I want to be suggested to use -f option when a Warning exception is raised ([#207](https://github.com/NASA-PDS/pds-doi-service/issues/207)) 
+## As a command-line user, I want to be suggested to use -f option when a Warning exception is raised ([#207](https://github.com/NASA-PDS/pds-doi-service/issues/207))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to run the commandline on windows ([#212](https://github.com/NASA-PDS/pds-doi-service/issues/212)) 
+## As a user, I want to run the commandline on windows ([#212](https://github.com/NASA-PDS/pds-doi-service/issues/212))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to search dois without case sensitiveness ([#223](https://github.com/NASA-PDS/pds-doi-service/issues/223)) 
+## As a user, I want to search dois without case sensitiveness ([#223](https://github.com/NASA-PDS/pds-doi-service/issues/223))
 
 
 This requirement is not impacted by the current version
-## As a user, I would like to include licensing information with all PDS DOIs ([#224](https://github.com/NASA-PDS/pds-doi-service/issues/224)) 
+## As a user, I would like to include licensing information with all PDS DOIs ([#224](https://github.com/NASA-PDS/pds-doi-service/issues/224))
 
 
 This requirement is not impacted by the current version
-## As an admistrator of the application,  I want to restrict access to API by specific referrer ([#228](https://github.com/NASA-PDS/pds-doi-service/issues/228)) 
+## As an admistrator of the application,  I want to restrict access to API by specific referrer ([#228](https://github.com/NASA-PDS/pds-doi-service/issues/228))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to include related DOIs in DOI metadata ([#232](https://github.com/NASA-PDS/pds-doi-service/issues/232)) 
+## As a user, I want to include related DOIs in DOI metadata ([#232](https://github.com/NASA-PDS/pds-doi-service/issues/232))
 
 
 This requirement is not impacted by the current version
-## As a PDS Operator, I want to perform a bulk update of a specific field across many DOI records ([#257](https://github.com/NASA-PDS/pds-doi-service/issues/257)) 
+## As a PDS Operator, I want to perform a bulk update of a specific field across many DOI records ([#257](https://github.com/NASA-PDS/pds-doi-service/issues/257))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to search for ids without case sensitiviy ([#271](https://github.com/NASA-PDS/pds-doi-service/issues/271)) 
+## As a user, I want to search for ids without case sensitiviy ([#271](https://github.com/NASA-PDS/pds-doi-service/issues/271))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to update the LIDVID associated with a DOI  ([#278](https://github.com/NASA-PDS/pds-doi-service/issues/278)) 
+## As a user, I want to update the LIDVID associated with a DOI  ([#278](https://github.com/NASA-PDS/pds-doi-service/issues/278))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to update the bundle/collection metadata associated with a DOI for accumulating data sets ([#279](https://github.com/NASA-PDS/pds-doi-service/issues/279)) 
+## As a user, I want to update the bundle/collection metadata associated with a DOI for accumulating data sets ([#279](https://github.com/NASA-PDS/pds-doi-service/issues/279))
 
 
 This requirement is not impacted by the current version
-## As an API user, I want to know the status value which can be expected ([#280](https://github.com/NASA-PDS/pds-doi-service/issues/280)) 
+## As an API user, I want to know the status value which can be expected ([#280](https://github.com/NASA-PDS/pds-doi-service/issues/280))
 
 
 This requirement is not impacted by the current version
-## As a user, I want a simplified DOI lifecycle workflow ([#286](https://github.com/NASA-PDS/pds-doi-service/issues/286)) 
+## As a user, I want a simplified DOI lifecycle workflow ([#286](https://github.com/NASA-PDS/pds-doi-service/issues/286))
 
 
 This requirement is not impacted by the current version
-## Update default values to sync with SBN documentation ([#295](https://github.com/NASA-PDS/pds-doi-service/issues/295)) 
+## Update default values to sync with SBN documentation ([#295](https://github.com/NASA-PDS/pds-doi-service/issues/295))
 
 
 This requirement is not impacted by the current version

--- a/docs/requirements/v2.1.2-dev/REQUIREMENTS.md
+++ b/docs/requirements/v2.1.2-dev/REQUIREMENTS.md
@@ -4,215 +4,215 @@ Requirements Summary
 
 # DOI management
 
-## The software shall be capable of accepting a request to create a draft DOI. ([#5](https://github.com/NASA-PDS/doi-service/issues/5)) 
+## The software shall be capable of accepting a request to create a draft DOI. ([#5](https://github.com/NASA-PDS/doi-service/issues/5))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to reserve a DOI. ([#6](https://github.com/NASA-PDS/doi-service/issues/6)) 
+## The software shall be capable of accepting a request to reserve a DOI. ([#6](https://github.com/NASA-PDS/doi-service/issues/6))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to release a DOI. ([#7](https://github.com/NASA-PDS/doi-service/issues/7)) 
+## The software shall be capable of accepting a request to release a DOI. ([#7](https://github.com/NASA-PDS/doi-service/issues/7))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to deactivate a DOI. ([#8](https://github.com/NASA-PDS/doi-service/issues/8)) 
+## The software shall be capable of accepting a request to deactivate a DOI. ([#8](https://github.com/NASA-PDS/doi-service/issues/8))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of accepting a request to update DOI metadata. ([#9](https://github.com/NASA-PDS/doi-service/issues/9)) 
+## The software shall be capable of accepting a request to update DOI metadata. ([#9](https://github.com/NASA-PDS/doi-service/issues/9))
 
 
 This requirement is not impacted by the current version
-## The software shall be capable of batch processing >1 DOI requests.	 ([#10](https://github.com/NASA-PDS/doi-service/issues/10)) 
+## The software shall be capable of batch processing >1 DOI requests.	 ([#10](https://github.com/NASA-PDS/doi-service/issues/10))
 
 
 This requirement is not impacted by the current version
 # DOI metadata
 
-## The software shall be capable of autonomously generating the minimum set of DOI metadata from PDS4 Collection, Bundle, Document products. ([#11](https://github.com/NASA-PDS/doi-service/issues/11)) 
+## The software shall be capable of autonomously generating the minimum set of DOI metadata from PDS4 Collection, Bundle, Document products. ([#11](https://github.com/NASA-PDS/doi-service/issues/11))
 
 
 This requirement is not impacted by the current version
-## The software shall validate a minimum set of metadata is provided when reserving, releasing, or updating a DOI. This minimum set of metadata will be defined by the PDS DOI Working Group. ([#12](https://github.com/NASA-PDS/doi-service/issues/12)) 
+## The software shall validate a minimum set of metadata is provided when reserving, releasing, or updating a DOI. This minimum set of metadata will be defined by the PDS DOI Working Group. ([#12](https://github.com/NASA-PDS/doi-service/issues/12))
 
 
 This requirement is not impacted by the current version
-## The software shall validate the DOI metadata when reserving, releasing, or updating a DOI. ([#13](https://github.com/NASA-PDS/doi-service/issues/13)) 
+## The software shall validate the DOI metadata when reserving, releasing, or updating a DOI. ([#13](https://github.com/NASA-PDS/doi-service/issues/13))
 
 
 This requirement is not impacted by the current version
 #  DOI interface support
 
-## The software shall maintain a database of PDS DOIs and their current state. ([#14](https://github.com/NASA-PDS/doi-service/issues/14)) 
+## The software shall maintain a database of PDS DOIs and their current state. ([#14](https://github.com/NASA-PDS/doi-service/issues/14))
 
 
 This requirement is not impacted by the current version
-## The software shall maintain the ability to manage DOIs through OSTI ([#15](https://github.com/NASA-PDS/doi-service/issues/15)) 
+## The software shall maintain the ability to manage DOIs through OSTI ([#15](https://github.com/NASA-PDS/doi-service/issues/15))
 
 
 This requirement is not impacted by the current version
-## The software shall maintain the ability to manage DOIs through DataCite. ([#16](https://github.com/NASA-PDS/doi-service/issues/16)) 
+## The software shall maintain the ability to manage DOIs through DataCite. ([#16](https://github.com/NASA-PDS/doi-service/issues/16))
 
 
 This requirement is not impacted by the current version
 # DOI-management
 
-## The software shall provide a Status capability that will allow a user to query for the current status of a DOI ([#30](https://github.com/NASA-PDS/doi-service/issues/30)) 
+## The software shall provide a Status capability that will allow a user to query for the current status of a DOI ([#30](https://github.com/NASA-PDS/doi-service/issues/30))
 
 
 This requirement is not impacted by the current version
-## The software shall provide the capability of producing a DOI Status Report based upon a user-specified query ([#35](https://github.com/NASA-PDS/doi-service/issues/35)) 
+## The software shall provide the capability of producing a DOI Status Report based upon a user-specified query ([#35](https://github.com/NASA-PDS/doi-service/issues/35))
 
 
 This requirement is not impacted by the current version
 # default
 
-## As a node operator, I want to include a DOI as a related identifier in the DOI metadata for parent PDS4 products. ([#69](https://github.com/NASA-PDS/doi-service/issues/69)) 
+## As a node operator, I want to include a DOI as a related identifier in the DOI metadata for parent PDS4 products. ([#69](https://github.com/NASA-PDS/doi-service/issues/69))
 
 
 This requirement is not impacted by the current version
-## As a node user, I want the LIDVID associated with a DOI to be automatically updated for accumulating bundles / collections. ([#97](https://github.com/NASA-PDS/doi-service/issues/97)) 
+## As a node user, I want the LIDVID associated with a DOI to be automatically updated for accumulating bundles / collections. ([#97](https://github.com/NASA-PDS/doi-service/issues/97))
 
 
 This requirement is not impacted by the current version
-## As the PDS, I want to mint DOIs through DataCite ([#103](https://github.com/NASA-PDS/doi-service/issues/103)) 
+## As the PDS, I want to mint DOIs through DataCite ([#103](https://github.com/NASA-PDS/doi-service/issues/103))
 
 
 This requirement is not impacted by the current version
-## Develop DOI Service - Registry integration component for accumulating bundles ([#111](https://github.com/NASA-PDS/doi-service/issues/111)) 
+## Develop DOI Service - Registry integration component for accumulating bundles ([#111](https://github.com/NASA-PDS/doi-service/issues/111))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to see the lidvid of my DOIs in the email report ([#167](https://github.com/NASA-PDS/doi-service/issues/167)) 
+## As a user, I want to see the lidvid of my DOIs in the email report ([#167](https://github.com/NASA-PDS/doi-service/issues/167))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to reserve a DOI through DataCite ([#171](https://github.com/NASA-PDS/doi-service/issues/171)) 
+## As an operator, I want to reserve a DOI through DataCite ([#171](https://github.com/NASA-PDS/doi-service/issues/171))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want query for one or more minted DOIs from DataCite ([#172](https://github.com/NASA-PDS/doi-service/issues/172)) 
+## As an operator, I want query for one or more minted DOIs from DataCite ([#172](https://github.com/NASA-PDS/doi-service/issues/172))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to query for a DOI's change history through DataCite ([#173](https://github.com/NASA-PDS/doi-service/issues/173)) 
+## As an operator, I want to query for a DOI's change history through DataCite ([#173](https://github.com/NASA-PDS/doi-service/issues/173))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to release a DOI through DataCite ([#174](https://github.com/NASA-PDS/doi-service/issues/174)) 
+## As an operator, I want to release a DOI through DataCite ([#174](https://github.com/NASA-PDS/doi-service/issues/174))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to update DOI metadata through DataCite ([#175](https://github.com/NASA-PDS/doi-service/issues/175)) 
+## As an operator, I want to update DOI metadata through DataCite ([#175](https://github.com/NASA-PDS/doi-service/issues/175))
 
 
 This requirement is not impacted by the current version
-## As an API user, I want to have pagination that is consistent with the PDS API. ([#176](https://github.com/NASA-PDS/doi-service/issues/176)) 
+## As an API user, I want to have pagination that is consistent with the PDS API. ([#176](https://github.com/NASA-PDS/doi-service/issues/176))
 
 
 This requirement is not impacted by the current version
-## As an API user I want to filter on lidvids with wildcards ([#177](https://github.com/NASA-PDS/doi-service/issues/177)) 
+## As an API user I want to filter on lidvids with wildcards ([#177](https://github.com/NASA-PDS/doi-service/issues/177))
 
 
 This requirement is not impacted by the current version
-## As an API user I want to filter on PDS3 Data Set IDs with wildcards ([#180](https://github.com/NASA-PDS/doi-service/issues/180)) 
+## As an API user I want to filter on PDS3 Data Set IDs with wildcards ([#180](https://github.com/NASA-PDS/doi-service/issues/180))
 
 
 This requirement is not impacted by the current version
-## As a user of the API, I want to see the DOI's title when I go GET /dois request ([#183](https://github.com/NASA-PDS/doi-service/issues/183)) 
+## As a user of the API, I want to see the DOI's title when I go GET /dois request ([#183](https://github.com/NASA-PDS/doi-service/issues/183))
 
 
 This requirement is not impacted by the current version
-## As an API user, I want to always have an update date for the DOIs ([#184](https://github.com/NASA-PDS/doi-service/issues/184)) 
+## As an API user, I want to always have an update date for the DOIs ([#184](https://github.com/NASA-PDS/doi-service/issues/184))
 
 
 This requirement is not impacted by the current version
-## As a SA, I want the operational deployment of the service to be secure ([#187](https://github.com/NASA-PDS/doi-service/issues/187)) 
+## As a SA, I want the operational deployment of the service to be secure ([#187](https://github.com/NASA-PDS/doi-service/issues/187))
 
 
 This requirement is not impacted by the current version
-## As a user, I want the application to support the history of PDS's DOIs, especially the one created for PDS3 products ([#192](https://github.com/NASA-PDS/doi-service/issues/192)) 
+## As a user, I want the application to support the history of PDS's DOIs, especially the one created for PDS3 products ([#192](https://github.com/NASA-PDS/doi-service/issues/192))
 
 
 This requirement is not impacted by the current version
-## As a system administrator, I want to be able to deploy pds_doi_service with python 3.6 ([#197](https://github.com/NASA-PDS/doi-service/issues/197)) 
+## As a system administrator, I want to be able to deploy pds_doi_service with python 3.6 ([#197](https://github.com/NASA-PDS/doi-service/issues/197))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to use the API with ids containing a slash (/) ([#198](https://github.com/NASA-PDS/doi-service/issues/198)) 
+## As a user, I want to use the API with ids containing a slash (/) ([#198](https://github.com/NASA-PDS/doi-service/issues/198))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to know what version of the software I am running ([#200](https://github.com/NASA-PDS/doi-service/issues/200)) 
+## As an operator, I want to know what version of the software I am running ([#200](https://github.com/NASA-PDS/doi-service/issues/200))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want to know how to deploy and use the API from the Sphinx documentation ([#201](https://github.com/NASA-PDS/doi-service/issues/201)) 
+## As an operator, I want to know how to deploy and use the API from the Sphinx documentation ([#201](https://github.com/NASA-PDS/doi-service/issues/201))
 
 
 This requirement is not impacted by the current version
-## As an operator, I want one place to go for all DOI Service / API / UI documentation ([#202](https://github.com/NASA-PDS/doi-service/issues/202)) 
+## As an operator, I want one place to go for all DOI Service / API / UI documentation ([#202](https://github.com/NASA-PDS/doi-service/issues/202))
 
 
 This requirement is not impacted by the current version
-## As a user of the command line, I don't want to see all the log info in the stdout ([#206](https://github.com/NASA-PDS/doi-service/issues/206)) 
+## As a user of the command line, I don't want to see all the log info in the stdout ([#206](https://github.com/NASA-PDS/doi-service/issues/206))
 
 
 This requirement is not impacted by the current version
-## As a command-line user, I want to be suggested to use -f option when a Warning exception is raised ([#207](https://github.com/NASA-PDS/doi-service/issues/207)) 
+## As a command-line user, I want to be suggested to use -f option when a Warning exception is raised ([#207](https://github.com/NASA-PDS/doi-service/issues/207))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to run the commandline on windows ([#212](https://github.com/NASA-PDS/doi-service/issues/212)) 
+## As a user, I want to run the commandline on windows ([#212](https://github.com/NASA-PDS/doi-service/issues/212))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to search dois without case sensitiveness ([#223](https://github.com/NASA-PDS/doi-service/issues/223)) 
+## As a user, I want to search dois without case sensitiveness ([#223](https://github.com/NASA-PDS/doi-service/issues/223))
 
 
 This requirement is not impacted by the current version
-## As a user, I would like to include licensing information with all PDS DOIs ([#224](https://github.com/NASA-PDS/doi-service/issues/224)) 
+## As a user, I would like to include licensing information with all PDS DOIs ([#224](https://github.com/NASA-PDS/doi-service/issues/224))
 
 
 This requirement is not impacted by the current version
-## As an admistrator of the application,  I want to restrict access to API by specific referrer ([#228](https://github.com/NASA-PDS/doi-service/issues/228)) 
+## As an admistrator of the application,  I want to restrict access to API by specific referrer ([#228](https://github.com/NASA-PDS/doi-service/issues/228))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to include related DOIs in DOI metadata ([#232](https://github.com/NASA-PDS/doi-service/issues/232)) 
+## As a user, I want to include related DOIs in DOI metadata ([#232](https://github.com/NASA-PDS/doi-service/issues/232))
 
 
 This requirement is not impacted by the current version
-## As a PDS Operator, I want to perform a bulk update of a specific field across many DOI records ([#257](https://github.com/NASA-PDS/doi-service/issues/257)) 
+## As a PDS Operator, I want to perform a bulk update of a specific field across many DOI records ([#257](https://github.com/NASA-PDS/doi-service/issues/257))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to search for ids without case sensitiviy ([#271](https://github.com/NASA-PDS/doi-service/issues/271)) 
+## As a user, I want to search for ids without case sensitiviy ([#271](https://github.com/NASA-PDS/doi-service/issues/271))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to update the LIDVID associated with a DOI  ([#278](https://github.com/NASA-PDS/doi-service/issues/278)) 
+## As a user, I want to update the LIDVID associated with a DOI  ([#278](https://github.com/NASA-PDS/doi-service/issues/278))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to update the bundle/collection metadata associated with a DOI for accumulating data sets ([#279](https://github.com/NASA-PDS/doi-service/issues/279)) 
+## As a user, I want to update the bundle/collection metadata associated with a DOI for accumulating data sets ([#279](https://github.com/NASA-PDS/doi-service/issues/279))
 
 
 This requirement is not impacted by the current version
-## As an API user, I want to know the status value which can be expected ([#280](https://github.com/NASA-PDS/doi-service/issues/280)) 
+## As an API user, I want to know the status value which can be expected ([#280](https://github.com/NASA-PDS/doi-service/issues/280))
 
 
 This requirement is not impacted by the current version
-## As a user, I want a simplified DOI lifecycle workflow ([#286](https://github.com/NASA-PDS/doi-service/issues/286)) 
+## As a user, I want a simplified DOI lifecycle workflow ([#286](https://github.com/NASA-PDS/doi-service/issues/286))
 
 
 This requirement is not impacted by the current version
-## Update default values to sync with SBN documentation ([#295](https://github.com/NASA-PDS/doi-service/issues/295)) 
+## Update default values to sync with SBN documentation ([#295](https://github.com/NASA-PDS/doi-service/issues/295))
 
 
 This requirement is not impacted by the current version
-## As a user, I want to sort by DOI, title, or identifier. ([#306](https://github.com/NASA-PDS/doi-service/issues/306)) 
+## As a user, I want to sort by DOI, title, or identifier. ([#306](https://github.com/NASA-PDS/doi-service/issues/306))
 
 
 This requirement is not impacted by the current version

--- a/docs/source/_static/swagger.html
+++ b/docs/source/_static/swagger.html
@@ -1,0 +1,664 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Planetary Data System DOI Service API</title>
+    <style type="text/css">
+      body {
+      	font-family: Trebuchet MS, sans-serif;
+      	font-size: 15px;
+      	color: #444;
+      	margin-right: 24px;
+      }
+
+      h1	{
+      	font-size: 25px;
+      }
+      h2	{
+      	font-size: 20px;
+      }
+      h3	{
+      	font-size: 16px;
+      	font-weight: bold;
+      }
+      hr	{
+      	height: 1px;
+      	border: 0;
+      	color: #ddd;
+      	background-color: #ddd;
+      }
+
+      .app-desc {
+        clear: both;
+        margin-left: 20px;
+      }
+      .param-name {
+        width: 100%;
+      }
+      .license-info {
+        margin-left: 20px;
+      }
+
+      .license-url {
+        margin-left: 20px;
+      }
+
+      .model {
+        margin: 0 0 0px 20px;
+      }
+
+      .method {
+        margin-left: 20px;
+      }
+
+      .method-notes	{
+      	margin: 10px 0 20px 0;
+      	font-size: 90%;
+      	color: #555;
+      }
+
+      pre {
+        padding: 10px;
+        margin-bottom: 2px;
+      }
+
+      .http-method {
+       text-transform: uppercase;
+      }
+
+      pre.get {
+        background-color: #0f6ab4;
+      }
+
+      pre.post {
+        background-color: #10a54a;
+      }
+
+      pre.put {
+        background-color: #c5862b;
+      }
+
+      pre.delete {
+        background-color: #a41e22;
+      }
+
+      .huge	{
+      	color: #fff;
+      }
+
+      pre.example {
+        background-color: #f3f3f3;
+        padding: 10px;
+        border: 1px solid #ddd;
+      }
+
+      code {
+        white-space: pre;
+      }
+
+      .nickname {
+        font-weight: bold;
+      }
+
+      .method-path {
+        font-size: 1.5em;
+        background-color: #0f6ab4;
+      }
+
+      .up {
+        float:right;
+      }
+
+      .parameter {
+        width: 500px;
+      }
+
+      .param {
+        width: 500px;
+        padding: 10px 0 0 20px;
+        font-weight: bold;
+      }
+
+      .param-desc {
+        width: 700px;
+        padding: 0 0 0 20px;
+        color: #777;
+      }
+
+      .param-type {
+        font-style: italic;
+      }
+
+      .param-enum-header {
+      width: 700px;
+      padding: 0 0 0 60px;
+      color: #777;
+      font-weight: bold;
+      }
+
+      .param-enum {
+      width: 700px;
+      padding: 0 0 0 80px;
+      color: #777;
+      font-style: italic;
+      }
+
+      .field-label {
+        padding: 0;
+        margin: 0;
+        clear: both;
+      }
+
+      .field-items	{
+      	padding: 0 0 15px 0;
+      	margin-bottom: 15px;
+      }
+
+      .return-type {
+        clear: both;
+        padding-bottom: 10px;
+      }
+
+      .param-header {
+        font-weight: bold;
+      }
+
+      .method-tags {
+        text-align: right;
+      }
+
+      .method-tag {
+        background: none repeat scroll 0% 0% #24A600;
+        border-radius: 3px;
+        padding: 2px 10px;
+        margin: 2px;
+        color: #FFF;
+        display: inline-block;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+  <h1>Planetary Data System DOI Service API</h1>
+    <div class="app-desc">PDS API for managing DOI registration with a DOI service provider (OSTI, DataCite, etc.).</div>
+    <div class="app-desc">More information: <a href="https://github.com/NASA-PDS/doi-service">https://github.com/NASA-PDS/doi-service</a></div>
+    <div class="app-desc">Contact Info: <a href="pds-operator@jpl.nasa.gov">pds-operator@jpl.nasa.gov</a></div>
+    <div class="app-desc">Version: 0.2</div>
+    <div class="app-desc">BasePath:/PDS_APIs/pds_doi_api/0.2</div>
+    <div class="license-info">All rights reserved</div>
+    <div class="license-url">http://apache.org/licenses/LICENSE-2.0.html</div>
+  <h2>Access</h2>
+
+  <h2><a name="__Methods">Methods</a></h2>
+  [ Jump to <a href="#__Models">Models</a> ]
+
+  <h3>Table of Contents </h3>
+  <div class="method-summary"></div>
+  <h4><a href="#Dois">Dois</a></h4>
+  <ul>
+  <li><a href="#getCheckDois"><code><span class="http-method">get</span> /dois/check</code></a></li>
+  <li><a href="#getDoiFromId"><code><span class="http-method">get</span> /doi</code></a></li>
+  <li><a href="#getDois"><code><span class="http-method">get</span> /dois</code></a></li>
+  <li><a href="#postDois"><code><span class="http-method">post</span> /dois</code></a></li>
+  <li><a href="#postSubmitDoi"><code><span class="http-method">post</span> /doi/submit</code></a></li>
+  <li><a href="#putDoiFromId"><code><span class="http-method">put</span> /doi</code></a></li>
+  </ul>
+
+  <h1><a name="Dois">Dois</a></h1>
+  <div class="method"><a name="getCheckDois"></a>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /dois/check</code></pre></div>
+    <div class="method-summary"> (<span class="nickname">getCheckDois</span>)</div>
+    <div class="method-notes">Check submission status of all records pending release.</div>
+
+
+
+
+
+    <h3 class="field-label">Query parameters</h3>
+    <div class="field-items">
+      <div class="param">email (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; If true, the check action sends results to the default recipients and pending DOI submitters. default: false </div>      <div class="param">attachment (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; If true, the check action sends results as an email attachment. Has no effect if the email flag is not set to true. default: false </div>      <div class="param">submitter (required)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; The email address of the user to register as author of the check action. This address is also included in the list of recipients. </div>    </div>  <!-- field-items -->
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#doi_record">doi_record</a>
+
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>""</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Success
+        <a href="#doi_record">doi_record</a>
+    <h4 class="field-label">400</h4>
+    DOI service provider cannot be reached
+        <a href="#"></a>
+    <h4 class="field-label">500</h4>
+    Internal error
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="getDoiFromId"></a>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /doi</code></pre></div>
+    <div class="method-summary"> (<span class="nickname">getDoiFromId</span>)</div>
+    <div class="method-notes">Get the status of a DOI from the transaction database.</div>
+
+
+
+
+
+    <h3 class="field-label">Query parameters</h3>
+    <div class="field-items">
+      <div class="param">identifier (required)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; The PDS identifier associated with the record to fetch. </div>    </div>  <!-- field-items -->
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#doi_record">doi_record</a>
+
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>""</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Success
+        <a href="#doi_record">doi_record</a>
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>[
+    {
+        &quot;creation_date&quot;:&quot;2021-03-09T00:00:00Z&quot;,
+        &quot;doi&quot;:&quot;10.17189/29476&quot;,
+        &quot;identifier&quot;:&quot;urn:nasa:pds:lab_shocked_feldspars::1.0&quot;,
+        &quot;node&quot;:&quot;eng&quot;,
+        &quot;record&quot;:&quot;&lt;?xml version&#x3D;\&quot;1.0\&quot; encoding&#x3D;\&quot;UTF-8\&quot;?&gt;\n&lt;records&gt;\n
+            &lt;record status&#x3D;\&quot;reserved\&quot;&gt;\n        &lt;id&gt;29476&lt;/id&gt;\n
+            &lt;title&gt;Laboratory Shocked Feldspars Bundle&lt;/title&gt;\n
+            &lt;doi&gt;10.17189/29476&lt;/doi&gt;\n        ...\n
+            &lt;contact_name&gt;PDS Operator&lt;/contact_name&gt;\n
+            &lt;contact_org&gt;PDS&lt;/contact_org&gt;\n
+            &lt;contact_email&gt;pds-operator@jpl.nasa.gov&lt;/contact_email&gt;\n
+            &lt;contact_phone&gt;818.393.7165&lt;/contact_phone&gt;\n
+            &lt;/record&gt;\n&lt;/records&gt;\n&quot;,
+        &quot;status&quot;:&quot;reserved&quot;,
+        &quot;submitter&quot;:&quot;my.email@node.gov&quot;
+    }
+]</code></pre>
+    <h4 class="field-label">404</h4>
+    Not existing
+        <a href="#"></a>
+    <h4 class="field-label">500</h4>
+    Internal error
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="getDois"></a>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /dois</code></pre></div>
+    <div class="method-summary"> (<span class="nickname">getDois</span>)</div>
+    <div class="method-notes">List the DOI requests within the transaction database</div>
+
+
+
+
+
+    <h3 class="field-label">Query parameters</h3>
+    <div class="field-items">
+      <div class="param">doi (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; List of DOIs to fetch from transaction database. </div>      <div class="param">submitter (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; List of submitter email addresses to filter DOIs by. </div>      <div class="param">node (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; List of PDS node names cited as contributor of the DOI to filter by. Each identifier must be one of the valid PDS steward IDs, see  https://pds.nasa.gov/datastandards/documents/dd/current/PDS4_PDS_DD_1D00.html#d5e72146 </div>      <div class="param">status (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; List of DOI workflow status values to filter results by. Status must be one of the following - &quot;unknown&quot;, &quot;draft&quot;, &quot;review&quot;, or &quot;findable&quot;. </div>      <div class="param">ids (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; List of PDS identifiers to filter DOIs by. Each identifier may contain one or more Unix-style wildcards (*) to pattern match against. </div>      <div class="param">start_date (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; A start date to filter resulting DOI records by. Only records with an update time after this date will be returned. Value must be a valid isoformat string of the form &lt;YYYY&gt;-&lt;mm&gt;-&lt;dd&gt;[T&lt;HH&gt;:&lt;MM&gt;:&lt;SS&gt;.&lt;ms&gt;] </div>      <div class="param">end_date (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; An end date to filter resulting DOI records by. Only records with an update time prior to this date will be returned. Value must be a valid isoformat string of the form &lt;YYYY&gt;-&lt;mm&gt;-&lt;dd&gt;[T&lt;HH&gt;:&lt;SS&gt;.&lt;ms&gt;] </div>    </div>  <!-- field-items -->
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      array[<a href="#doi_summary">doi_summary</a>]
+
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>[
+    {
+        "identifier" : "identifier",
+        "node" : "node",
+        "submitter" : "submitter",
+        "title" : "title",
+        "update_date" : "2000-01-23T04:56:07.000+00:00",
+        "doi" : "doi",
+        "status" : "status"
+    },
+    {
+        "identifier" : "identifier",
+        "node" : "node",
+        "submitter" : "submitter",
+        "title" : "title",
+        "update_date" : "2000-01-23T04:56:07.000+00:00",
+        "doi" : "doi",
+        "status" : "status"
+    }
+]</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Success
+
+    <h4 class="field-label">400</h4>
+    Invalid Argument
+        <a href="#"></a>
+    <h4 class="field-label">500</h4>
+    Internal error
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="postDois"></a>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /dois</code></pre></div>
+    <div class="method-summary"> (<span class="nickname">postDois</span>)</div>
+    <div class="method-notes">Submit a DOI to reserve or update. The payload includes URLs for one or more  records to be submitted. Record URLs must resolve to PDS4 label files (xml).</div>
+
+
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="header">Content-Type</span> request header:
+    <ul>
+      <li><code>application/json</code></li>
+      <li><code>application/xml</code></li>
+    </ul>
+
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">body <a href="#labels_payload">labels_payload</a> (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash; Payload containing one or more labels in JSON or XML (PDS4) format. Required for reserve requests, but optional for update. </div>
+            <div class="param-desc"><span class="param-type">example: <code>{
+  &quot;labels&quot; : [ {
+    &quot;status&quot; : &quot;Reserved&quot;,
+    &quot;title&quot; : &quot;Laboratory Shocked Feldspars Bundle&quot;,
+    &quot;publication_date&quot; : &quot;2020-03-11&quot;,
+    &quot;product_type_specific&quot; : &quot;PDS4 Collection&quot;,
+    &quot;author_last_name&quot; : &quot;Johnson&quot;,
+    &quot;author_first_name&quot; : &quot;J. R.&quot;,
+    &quot;related_resource&quot; : &quot;urn:nasa:pds:lab_shocked_feldspars&quot;
+  } ]
+}</code></span></div>    </div>  <!-- field-items -->
+
+
+    <h3 class="field-label">Query parameters</h3>
+    <div class="field-items">
+      <div class="param">action (required)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; The submission action to perform. Must be one of &quot;reserve&quot;, &quot;draft&quot; or &quot;update&quot;. &quot;draft&quot; is an alias for &quot;update&quot;. </div>      <div class="param">submitter (required)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; Email address of the submission requester. </div>      <div class="param">node (required)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; The PDS node name to cite as contributor of the DOI. Must be one of the valid PDS steward IDs, see  https://pds.nasa.gov/datastandards/documents/dd/current/PDS4_PDS_DD_1D00.html#d5e72146 </div>      <div class="param">url (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; URL to provide as the record to register a DOI for. URL must start with either &quot;http://&quot; or &quot;https://&quot; and resolve to a valid PDS4 label in XML format. This value is only utilized when request is set to &quot;update&quot;. </div>      <div class="param">force (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; If true, forces a reserve request to completion, ignoring any warnings encountered. Has no effect for update requests. default: false </div>    </div>  <!-- field-items -->
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#doi_record">doi_record</a>
+
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>""</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Success
+        <a href="#doi_record">doi_record</a>
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>[
+    {
+        &quot;creation_date&quot;:&quot;2021-03-09T00:00:00Z&quot;,
+        &quot;doi&quot;:&quot;10.17189/29476&quot;,
+        &quot;identifier&quot;:&quot;urn:nasa:pds:lab_shocked_feldspars::1.0&quot;,
+        &quot;node&quot;:&quot;eng&quot;,
+        &quot;record&quot;:&quot;&lt;?xml version&#x3D;\&quot;1.0\&quot; encoding&#x3D;\&quot;UTF-8\&quot;?&gt;\n
+            &lt;records&gt;\n    &lt;record status&#x3D;\&quot;reserved\&quot;&gt;\n
+            &lt;id&gt;29476&lt;/id&gt;\n        &lt;title&gt;Laboratory Shocked Feldspars Bundle&lt;/title&gt;\n
+            &lt;doi&gt;10.17189/29476&lt;/doi&gt;\n        ...\n
+            &lt;contact_name&gt;PDS Operator&lt;/contact_name&gt;\n
+            &lt;contact_org&gt;PDS&lt;/contact_org&gt;\n
+            &lt;contact_email&gt;pds-operator@jpl.nasa.gov&lt;/contact_email&gt;\n
+            &lt;contact_phone&gt;818.393.7165&lt;/contact_phone&gt;\n
+            &lt;/record&gt;\n&lt;/records&gt;\n&quot;,
+        &quot;status&quot;:&quot;reserved&quot;,
+        &quot;submitter&quot;:&quot;my.email@node.gov&quot;
+     }
+]</code></pre>
+    <h4 class="field-label">201</h4>
+    Success
+        <a href="#"></a>
+    <h4 class="field-label">400</h4>
+    Invalid Argument
+        <a href="#"></a>
+    <h4 class="field-label">500</h4>
+    Internal error
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="postSubmitDoi"></a>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /doi/submit</code></pre></div>
+    <div class="method-summary"> (<span class="nickname">postSubmitDoi</span>)</div>
+    <div class="method-notes">Move a DOI record from draft status to &quot;review&quot;.</div>
+
+
+
+
+
+    <h3 class="field-label">Query parameters</h3>
+    <div class="field-items">
+      <div class="param">identifier (required)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; The PDS identifier associated with the record to submit for review. </div>      <div class="param">force (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; If true, forces a submit request to completion, ignoring any warnings encountered. default: false </div>    </div>  <!-- field-items -->
+
+
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#doi_record">doi_record</a>
+
+    </div>
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    <h3 class="field-label">Example data</h3>
+    <div class="example-data-content-type">Content-Type: application/json</div>
+    <pre class="example"><code>""</code></pre>
+
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="header">Content-Type</span> response header.
+    <ul>
+      <li><code>application/json</code></li>
+    </ul>
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">200</h4>
+    Success
+        <a href="#doi_record">doi_record</a>
+    <h4 class="field-label">400</h4>
+    Can not be released
+        <a href="#"></a>
+    <h4 class="field-label">404</h4>
+    No entry found for identifier
+        <a href="#"></a>
+    <h4 class="field-label">500</h4>
+    Internal error
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+  <div class="method"><a name="putDoiFromId"></a>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="put"><code class="huge"><span class="http-method">put</span> /doi</code></pre></div>
+    <div class="method-summary"> (<span class="nickname">putDoiFromId</span>)</div>
+    <div class="method-notes">Update the record associated with an existing DOI.</div>
+
+
+
+
+
+    <h3 class="field-label">Query parameters</h3>
+    <div class="field-items">
+      <div class="param">identifier (required)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; The PDS identifier associated with the record to fetch. </div>      <div class="param">submitter (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; Email address of the DOI update requester. </div>      <div class="param">node (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; The PDS node name to cite as contributor of the DOI. Must be one of the valid PDS steward IDs, see  https://pds.nasa.gov/datastandards/documents/dd/current/PDS4_PDS_DD_1D00.html#d5e72146 </div>      <div class="param">url (optional)</div>
+
+            <div class="param-desc"><span class="param-type">Query Parameter</span> &mdash; URL to provide as the record to update the DOI with. URL must start with either &quot;http://&quot; or &quot;https://&quot; and resolve to a valid PDS4 label in XML format. </div>    </div>  <!-- field-items -->
+
+
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+
+
+    <h3 class="field-label">Responses</h3>
+    <h4 class="field-label">501</h4>
+    Not implemented
+        <a href="#"></a>
+  </div> <!-- method -->
+  <hr/>
+
+  <h2><a name="__Models">Models</a></h2>
+  [ Jump to <a href="#__Methods">Methods</a> ]
+
+  <h3>Table of Contents</h3>
+  <ol>
+    <li><a href="#doi_record"><code>doi_record</code></a></li>
+    <li><a href="#doi_summary"><code>doi_summary</code></a></li>
+    <li><a href="#label_payload"><code>label_payload</code></a></li>
+    <li><a href="#labels_payload"><code>labels_payload</code></a></li>
+  </ol>
+
+  <div class="model">
+    <h3><a name="doi_record"><code>doi_record</code></a> <a class="up" href="#__Models">Up</a></h3>
+
+    <div class="field-items">
+      <div class="param">doi (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">identifier (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">title (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">node (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">submitter (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">status (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">update_date (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span>  format: date-time</div>
+<div class="param">record (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> full DOI label </div>
+<div class="param">creation_date (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span> Creation date of the DOI record in iso8601 format format: date-time</div>
+<div class="param">message (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="doi_summary"><code>doi_summary</code></a> <a class="up" href="#__Models">Up</a></h3>
+
+    <div class="field-items">
+      <div class="param">doi (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">identifier (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">title (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">node (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">submitter (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">status (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">update_date (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span>  format: date-time</div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="label_payload"><code>label_payload</code></a> <a class="up" href="#__Models">Up</a></h3>
+
+    <div class="field-items">
+      <div class="param">status (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">title (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">publication_date (optional)</div><div class="param-desc"><span class="param-type"><a href="#DateTime">Date</a></span>  format: date-time</div>
+<div class="param">product_type_specific (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">author_last_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">author_first_name (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">related_resource (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="labels_payload"><code>labels_payload</code></a> <a class="up" href="#__Models">Up</a></h3>
+
+    <div class="field-items">
+      <div class="param">labels (optional)</div><div class="param-desc"><span class="param-type"><a href="#label_payload">array[label_payload]</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  </body>
+</html>

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -1,0 +1,32 @@
+️Command Line API
+=================
+
+This section contains details on the interfaces for the command line tools.
+
+pds-doi-cmd
+-----------
+
+.. argparse::
+   :module: pds_doi_service.core.actions.action
+   :func: create_parser
+   :prog: pds-doi-cmd
+
+pds-doi-init
+------------
+
+.. argparse::
+    :module: pds_doi_service.core.util.initialize_production_deployment
+    :func: create_cmd_parser
+    :prog: pds-doi-init
+
+Swagger API
+===========
+
+This section contains details Swagger REST API implemented by ``pds-doi-api``.
+
+.. raw:: html
+    :file: ../_static/swagger.html
+
+
+.. _Readme: https://github.com/NASA-PDS/doi-ui#readme
+.. _DataCite: https://datacite.org

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'PDS DOI Service'
-copyright = '2020–2021 California Institute of Technology'
+copyright = '2020–2022 California Institute of Technology'
 author = 'NASA PDS Engineering Node'
 
 
@@ -33,6 +33,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinx.ext.autosummary',
+    'sphinx.ext.napoleon',
     'sphinx_rtd_theme',
     'sphinxarg.ext',
 ]

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -6,7 +6,7 @@ Quick start
 
 To obtain a copy of the code and work on a new branch::
 
-    git clone https://github.com/NASA-PDS/pds-doi-service.git
+    git clone https://github.com/NASA-PDS/doi-service.git
     git checkout -b "<issue number>_<issue name>"
 
 Create a virtual environment in ``venv`` using Python 3.9 or later::
@@ -45,7 +45,7 @@ Making Releases
 Releases are done on GitHub and PyPI. This is implemented through the CI/CD
 framework using GitHub Actions_ on the ``main`` branch. To trigger a release
 via the CI/CD framework, create a branch named ``release/<version number>``,
-and push it to the GitHub origin (https://github.com/NASA-PDS/pds-doi-service.git)
+and push it to the GitHub origin (https://github.com/NASA-PDS/doi-service.git)
 to trigger the Actions_ framework for release, for example::
 
     git checkout -b release/1.2
@@ -57,7 +57,7 @@ number, tag and build a release, and push it to PyPI.
 Contribute
 ----------
 
-Clone the repo from : https://github.com/NASA-PDS/pds-doi-service and then
+Clone the repo from : https://github.com/NASA-PDS/doi-service and then
 submit a pull request for your branch when complete. At least one PDS Engineering
 Node developer must approve the request before it is merged.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,8 +17,9 @@ Currently, this service is deployed as a Python package
    :caption: Contents:
 
    installation/index
-   usage/index
    development/index
+   usage/index
+   api/index
    support/index
 
 

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -3,11 +3,6 @@
 
 This section describes how to install the PDS DOI Service.
 
-The service is composed of a command line tool (``pds-doi-cmd``) and a web API
-(``pds-doi-api``) which provides an interface to the command line that may be
-accessed remotely or via web UI.
-
-
 Requirements
 ------------
 

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -1,63 +1,296 @@
-🏃‍♀️ Usage
-===========
+**********
+🏃‍ ️Usage
+**********
 
-.. toctree::
+This section describes how to use the PDS DOI Service.
 
+The service is composed of command line tools (``pds-doi-cmd``, ``pds-doi-init``),
+as well as a web API (``pds-doi-api``) which provides a REST interface to the DOI
+service.
+
+A DOI Service GUI is also available for interfacing with the web API from a browser,
+however, it is provided as a separate application with its own github repository.
+For more information on installing and running the PDS DOI UI, consult its `Readme`_.
 
 Overview
---------
+========
 
-A DOI (Digital Object Identifier) is a URI which is used to permanently identify
-a digital object, typically a dataset or document.
-The DOI is then used to cite the digital object, especially in scientific papers.
+A DOI (Digital Object Identifier) is a handle which is used to permanently identify
+a digital object, typically a dataset or document. Once assigned, a DOI is
+typically used to cite the digital object, especially in scientific papers.
 
 In the context of PDS, publishing a new DOI follows this workflow:
 
     - ``Reserve``: Before a dataset is published in PDS, a DOI is reserved so the
-      researchers working with the digital resource can cite it at early stage.
-    - ``Draft``: The metadata associated to an existing DOI is elaborated and validated.
+      researchers working with the digital resource may cite it at early stage.
+    - ``Update``: The metadata associated to an existing DOI is elaborated and validated,
+      but without submission to the DOI provider (`DataCite`_).
     - ``Review``: Once all metadata has been properly associated to the DOI, the
       requester submits the DOI record for review to the PDS Engineering node.
     - ``Release``: After the PDS Engineering node determines that the DOI record is
-      filled out properly, the DOI and its metadata is officially registered at
+      filled out properly, the DOI and its metadata are officially registered at
       `DataCite`_ and made available for public discovery. If there any issues with
-      the reviewed record, PDS Engineering node may move the record back to ``Draft``
-      status for correction by the original submitter.
+      the reviewed record, PDS Engineering node may move the record back to a hidden
+      status until correction by the original submitter. Corrections may be made
+      via the ``Update`` action. Once updated, the record can be re-released to
+      move it back to findable status.
 
-The Draft and Release steps may be repeated multiple times to update the metadata
-associated to the DOI.
-
-Inputs to DOI creation (the Reserve step) are either PDS4 labels or ad-hoc
-spreadsheets.
+The Update, Review and Release steps may be repeated multiple times to iterate on
+the metadata associated to the DOI. However, a Reserve should only ever occur once.
 
 The metadata managed with DOIs is meant to be preserved and traceable, as it is
 used to permanently cite a digital resource. For this reason, all transactions,
 creations, and updates with the PDS DOI Service are registered in a local database.
 This database is used to track submissions-in-progress and help ensure the proper
-workflow (``Reserve`` → ``Draft`` → ``Review`` → ``Release``) is enforced.
+workflow (``Reserve`` → ``Update`` → ``Review`` → ``Release``) is enforced.
 
-Currently, the service provides a command line tool for use by a PDS Engineering
-Node operator interacting with the Discipline Nodes, as well as a web API and UI
-to enable Discipline Nodes to directly manage their DOIs.
+Currently, the service provides a set command line tools for use by PDS Engineering
+Node operators to interact directly with the local PDS DOI Service installation and its
+transaction database. A web API is also available to facilitate management of DOIs
+by other PDS discipline nodes (for example, when used with the DOI Service GUI).
 
-Command Line Usage Information
-------------------------------
+Command Line Application Descriptions
+=====================================
 
 pds-doi-cmd
-^^^^^^^^^^^
+-----------
 
-.. argparse::
-   :module: pds_doi_service.core.actions.action
-   :func: create_parser
-   :prog: pds-doi-cmd
+``pds-doi-cmd`` is the primary command line interface for interacting with the
+PDS DOI Service. After installing the service and activating its virtual
+environment, the ``pds-doi-cmd`` application may be accessed directly from the
+command prompt::
+
+    $ pds-doi-cmd --help
+
+The application provides a number of subcommands for specific requests, which
+loosely map to the workflow actions defined above. A subcommand must be specified
+as the first argument to ``pds-doi-cmd``, after which, additional arguments may
+be provided to configure the behavior of said subcommand. All subcommands provide
+a ``--help`` flag to obtain a description of the available arguments::
+
+    $ pds-doi-cmd reserve --help
+
+Descriptions of the various subcommands and their usages are provided below.
+For a full description of all available subcommand and their arguments, consult
+the `api`_ section.
+
+pds-doi-cmd reserve
+^^^^^^^^^^^^^^^^^^^
+
+The `reserve` subcommand allows a new DOI to be reserved by the DOI provider.
+Once reserved, the assigned DOI may be used for citation purposes while metadata
+is still being associated with the DOI record.
+
+In DataCite parlance, a reserved DOI is initially kept in the "draft" state,
+meaning the DOI is reserved, but not publicly findable. A draft DOI may also be
+deleted using DataCite's REST API so the identifier may be returned to the pool
+of reservable DOI's for PDS.
+
+Input to the reserve subcommand is either a PDS4 XML label, or a spreadsheet in
+CSV or Excel (.xls or .xlsx) format containing rows for each object to reserve a
+DOI for. PDS4 labels are expected to conform to the PDS4 schema and not have a
+DOI already assigned within them. Spreadsheets are expected to define several
+mandatory columns and provide a header row with the name of each column (in any order).
+
+An example CSV-format spreadsheet for a reserve request is provided below::
+
+    title,publication_date,product_type_specific,author_last_name,author_first_name,related_resource
+    Laboratory Shocked Feldspars Collection,2020-03-11,PDS4 Refereed Collection,Johnson,J. R.,urn:nasa:pds:lab_shocked_feldspars::1.0
+
+Where the following are mandatory columns:
+    * ``title`` : The title of the object to reserve a DOI for. Should not match any existing titles with DOI's assigned.
+    * ``publication_date`` : The date of the object's publication in `YYYY-MM-DD` format.
+    * ``product_type_specific`` : The type of the object. Should be one of `PDS4 Refereed Collection`, `PDS4 Refereed Document`, or `PDS4 Refereed Data Bundle` (note that `PDS3` may be used in lieu of `PDS4` if working with PDS3 objects)
+    * ``author_last_name`` : Last name of the author of the object.
+    * ``author_first_name`` : First name of the author of the object.
+    * ``related_resource`` : The PDS4 LIDVID identifier associated with the object. If working with a PDS3 object, the PDS3 Site ID may be used instead.
+
+Additionally, the following optional columns may also be provided:
+    * ``doi`` : An existing DOI already assigned to the object. Should only be provided when using spreadsheets as input for an `update` or `release` action.
+    * ``description`` : Free text description of the object.
+    * ``site_url`` : URL to the landing page to be associated with the DOI.
+    * ``node_id`` : A PDS node identifier to associate with the DOI metadata. Should be one of `atm`, `geo`, `img`, `naif`, `ppi`, `rs`, `rms`, or `sbn`.
+
+If the reserve request is successful, the `reserve` subcommand returns a DataCite
+format JSON label containing the reserved DOI records. This label may be saved
+to disk and modified to include any additional metadata needed before release.
+An updated JSON label may then be provided to the `update` or `release` actions, as
+the workflow dictates.
+
+pds-doi-cmd update
+^^^^^^^^^^^^^^^^^^
+
+The `update` subcommand allows the metadata associated with a reserved (or released)
+record to be updated locally within the PDS DOI Service prior to submission to
+DataCite. All updates made with the `update` action remain local to the installation
+of the PDS DOI Service until released to DataCite, so an update request will not
+change the findable status of an existing DOI record within DataCite.
+
+Input to the `update` subcommand may be either a PDS4 label or spreadsheet (described
+in the `reserve` section above), or a DataCite format JSON label. A DataCirte label
+may be obtained as the output from a previous action or querired for via the `list`
+action, described later in this document. Regardless of the format, the input must
+define an existing DOI value for each provided record. These DOI values must also
+already exist within the transaction database for the PDS DOI Service installation
+(i.e. they were part of a previous reserve request made by the same installation of
+the service).
+
+If the update request is successful, the `update` subcommand returns a DataCite
+format JSON label representing the updated state of each record. This label may
+be saved off and reused with the `release` command to push the updates to DataCite.
+
+pds-doi-cmd release
+^^^^^^^^^^^^^^^^^^^
+
+The `release` subcommand encompasses both the ``Review`` and ``Release`` steps
+of the DOI workflow described above. It should be used when a reserved DOI
+record is completed with all required metadata (via the `update` action).
+
+According to DataCite's documentation, the following fields must be provided
+before a release:
+
+    * ``DOI`` : The DOI assigned by the reserve request
+    * ``creators`` : The list of authors associated of the record
+    * ``title`` : Title of the record
+    * ``publisher`` : The publisher of the record
+    * ``publicationYear`` : Year of record publication
+    * ``resourceTypeGeneral`` : The type of record (dataset, document, etc.)
+
+Note that all of these fields are set for you by the PDS DOI Service based on
+values parsed from the input to a reserve request, however, they should not
+typically not be removed or modified by update requests.
+
+Whether the `release` action performs a release to the ``Review`` stage (for
+internal review and approval by the PDS Engineering node) or directly to DataCite
+as a findable record, is controlled by means of the ``--no-review`` argument to
+the `release` subcommand.
+
+To release a record to the ``Review`` stage::
+
+    $ pds-doi-cmd release --input <your input file>
+
+To release a record directly to DataCite::
+
+    $ pds-doi-cmd release --no-review --input <your input file>
+
+In DataCite parlance, released DOI records are moved into the "findable" state,
+meaning they can be searched for on doi.org. A DOI moved to the findable state
+may no longer be deleted (aka returned to the pool of our available DOI's), but
+may still be updated or moved back into a hidden state. Note that moving a record
+back to the hidden state currently **cannot** be performed via the PDS DOI Service.
+
+The output of the `release` command is a DataCite format JSON label containing the
+state of the record after release to review or DataCite.
+
+pds-doi-cmd list
+^^^^^^^^^^^^^^^^
+
+The `list` subcommand is used primarily to query the local transaction database
+for the current state of DOI record submission requests. User's may provide
+one or more filters to subset query results to specific DOI's, PDS identifiers,
+workflow status, or a start/end date range of last update.
+
+A particularly useful use-case is using the `list` action to obtain the set of
+DOI records in ``Review`` state which are awaiting approval by PDS Engineering
+node prior to release to DataCite::
+
+    $ pds-doi-cmd list --status review
+
+Or checking the submission status for a particular LIDVID or Dataset ID::
+
+    $ pds-doi-cmd list --ids urn:nasa:pds:lab_shocked_feldspars::1.0
+
+Certain filter options, such as ``--ids``, ``--doi``, allow one or more Unix-style
+wildcards (``*``) to be provided within each argument to pattern match against.
+A useful case is obtaining all records associated to a LID with multiple VIDs::
+
+    $ pds-doi-cmd list --ids urn:nasa:pds:lab_shocked_feldspars::*
+
+By default, the results of a `list` query are returned as JSON-formatted database
+records, reflecting the state of the DOI record within the transaction database.
+However, the `list` subcommand may also be instructed to return matching records
+as a DataCite format JSON label via the ``--format`` argument::
+
+    $ pds-doi-cmd list --doi 10.12345/abcdef --format label
+
+This can be very useful for obtaining a single label file containing multiple
+records to be updated in tandem. The modified label may then be provided as the
+input to the `update` or `release` subcommands.
+
+pds-doi-cmd check
+^^^^^^^^^^^^^^^^^
+
+In older versions of the PDS DOI Service, the `check` subcommand was used to check
+the state of DOI records that had been released, but left in a "pending" state by
+the DOI provider. Since the transition to DataCite as the backend DOI provider,
+the `check` action is no longer necessary and has been deprecated. It should no
+longer be used.
+
+Future versions of the PDS DOI Service may repurpose the `check` subcommand to be
+useful within the context of DataCite submissions.
+
 
 pds-doi-init
-^^^^^^^^^^^^
+------------
 
-.. argparse::
-    :module: pds_doi_service.core.util.initialize_production_deployment
-    :func: create_cmd_parser
-    :prog: pds-doi-init
+The ``pds-doi-init`` command line application is used to synchronize the local
+transaction database with the status of DOI records pulled directly from DataCite.
+A DataCite format JSON label containing records may also be used in-lieu of a
+direct pull from DataCite.
 
-.. _OSTI: https://www.osti.gov/data-services
+This script is useful in instances where a transaction database must be rebuilt
+from scratch on a fresh installation of the service, or when an update to the
+service invalidates an existing transaction database (due to table schema changes
+and the like).
+
+The script may also be used to pull entries from DataCite for DOI prefixes other
+than the one assigned to PDS. This can be helpful for keeping in sync with other
+PDS nodes that may have submitted DOI records with their own prefix.
+
+Running ``pds-doi-init`` requires that the appropriate DataCite credentials and
+endpoint URL are defined in the INI config. See the `installation`_ section for
+more details.
+
+A full description of the ``pds-doi-init`` application and its arguments may be
+found in the `api`_ section.
+
+pds-doi-api
+-----------
+
+The ``pds-doi-api`` script is the main interface for launching the REST API used
+to interact with the core PDS DOI Service library. The script launches the API
+within a `waitress`_ application server.
+
+The host IP address and port the API binds to at launch are configured by the INI
+config. See the `installation`_ section for more details on configuring the INI.
+
+``pds-doi-api`` takes no arguments, however, it is typical to launch the API using
+``screen`` or ``nohup`` to ensure the process remains after an operator has launched
+it and logged out of the host system::
+
+    $ nohup pds-doi-api > nohup.out &
+
+You can explore the API documentation and test it using its built-in Swagger UI.
+To access the test UI, navigate to http://localhost:8080/PDS_APIs/pds_doi_api/0.2/ui/
+using a web-browser on the same machine that is running the API service (or a machine
+with an SSH tunnel to the host machine). Note that this assumes the host and port
+configured in the INI are set to ``localhost`` and ``8080``, respectively.
+
+..  note::
+
+    In order to access the built-in Swagger UI, there must **not** be any value
+    set for the ``OTHER.api_valid_referrers`` section of the INI config. To
+    ensure the value is not set, add the following the user configuration file
+    described in the Configuration section above::
+
+        [OTHER]
+        api_valid_referrers =
+
+A copy of the Swagger API definition, with available endpoints and URL query
+parameters, for the ``pds-doi-api`` application is available within the `api`_ section.
+
+.. _api: ../api/index.html
+.. _installation: ../installation/index.html
+.. _Readme: https://github.com/NASA-PDS/doi-ui#readme
 .. _DataCite: https://datacite.org
+.. _waitress: https://docs.pylonsproject.org/projects/waitress/en/latest/

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ dev =
     pytest-xdist
     pre-commit
     sphinx
-    sphinx-rtd-theme
+    sphinxcontrib-napoleon
     tox
     flask_testing==0.8.0
     sphinx-rtd-theme==0.5.0

--- a/src/pds_doi_service/core/actions/action.py
+++ b/src/pds_doi_service/core/actions/action.py
@@ -55,6 +55,8 @@ class DOICoreAction:
         """
         parser = argparse.ArgumentParser(
             description="PDS core command for DOI management. The available subcommands are:\n",
+            epilog="Usage for each subcommand is available by providing the --help argument to the subcommand:\n"
+                   "    pds-doi-cmd reserve --help\n",
             formatter_class=argparse.RawTextHelpFormatter,
         )
 

--- a/src/pds_doi_service/core/actions/list.py
+++ b/src/pds_doi_service/core/actions/list.py
@@ -106,7 +106,8 @@ class DOICoreActionList(DOICoreAction):
             "--doi",
             required=False,
             metavar="DOI[,DOI]...",
-            help="A list of comma-delimited DOI values to use as filters with the database query.",
+            help="A list of comma-delimited DOI values to use as filters with the database query. "
+            "Each DOI may contain one or more wildcards (*) to pattern match against.",
         )
         action_parser.add_argument(
             "-i",


### PR DESCRIPTION
## 🗒️ Summary
This PR makes a number of additions the set of ghpages documentation bundled with the DOI service. In particular, the usage page has received a large update to include in-depth descriptions for the `pds-doi-cmd` actions, and a new API page has been added to roll up the Sphinx-generated API docs for the command-line utilities. Lastly, a static HTML render of the Swagger API has been added to document the usage for `pds-doi-api`.

## ⚙️ Test Data and/or Report
No core functionality added/modified by this PR, no tests have been updated.

## ♻️ Related Issues
Resolves #201 
Resolves #202
Resolves #256 
Resolves #313 

<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


