### PR TITLE
Add sync script and update identifier handling

### DIFF
--- a/scripts/sync_dois.sh
+++ b/scripts/sync_dois.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help)
+      echo "sync_dois.sh [-h|--help] [-p|--prefix <doi_prefix>] [-s|--submitter <submitter email>]"
+      exit 0
+      ;;
+    -p|--prefix)
+      PREFIX="$2"
+      shift
+      shift
+      ;;
+    -s|--submitter)
+      SUBMITTER="$2"
+      shift
+      shift
+      ;;
+    *)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z ${PREFIX} ]]; then
+  PREFIX="10.17189"
+fi
+
+if [[ -z ${SUBMITTER} ]]; then
+  SUBMITTER="pds-operator@jpl.nasa.gov"
+fi
+
+echo "=================================================="
+echo "Starting DOI sync for $(date)"
+echo
+echo "PREFIX=${PREFIX}"
+echo "SUBMITTER=${SUBMITTER}"
+
+source /home/pds4/pds-doi-service/bin/activate
+
+pds-doi-init --service datacite --prefix ${PREFIX} --submitter ${SUBMITTER}
+
+echo "Sync complete"
+echo
+
+exit 0

--- a/src/pds_doi_service/core/outputs/datacite/datacite_web_parser.py
+++ b/src/pds_doi_service/core/outputs/datacite/datacite_web_parser.py
@@ -108,7 +108,11 @@ class DOIDataCiteWebParser(DOIWebParser):
             identifiers = record["identifiers"]
 
             for identifier in identifiers:
-                identifier["identifier"] = identifier["identifier"].strip()
+                if identifier["identifier"] is None:
+                    logger.warn(f"Odd metadata. NoneType identifier in record: {json.dumps(record, indent=4, sort_keys=True)}")
+                    identifiers.remove(identifier)
+                else:
+                    identifier["identifier"] = identifier["identifier"].strip()
 
             return identifiers
         except KeyError:


### PR DESCRIPTION
## 🗒️ Summary
* Add sync_dois.sh script per #309
* Update identifier handling for NoneType identifiers #331

## ⚙️ Test Data and/or Report
```
$ scripts/sync_dois.sh --prefix 10.26007
...
WARNING pds_doi_service.core.outputs.datacite.datacite_web_parser:_parse_identifiers Odd metadata. NoneType identifier in record:
...
    "identifiers": [
        {
            "identifier": "urn:nasa:pds:dart_teleobs::1.0",
            "identifierType": "PDS4 Bundle ID"
        },
        {
            "identifier": null,
            "identifierType": null
        }
    ],
...
INFO pds_doi_service.core.util.initialize_production_deployment:main DOI import complete in 5.12 seconds.
INFO pds_doi_service.core.util.initialize_production_deployment:main Num records found: 25
INFO pds_doi_service.core.util.initialize_production_deployment:main Num records processed: 25
INFO pds_doi_service.core.util.initialize_production_deployment:main Num records written: 0
INFO pds_doi_service.core.util.initialize_production_deployment:main Num records skipped: 25
Sync complete
```

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
fixes #331

