### PR TITLE
Issue 336 - DOI-service application inaccurately reports LID as being invalid

### DIFF
--- a/src/pds_doi_service/core/outputs/doi_validator.py
+++ b/src/pds_doi_service/core/outputs/doi_validator.py
@@ -368,17 +368,25 @@ class DOIValidator:
                     raise InvalidIdentifierException(
                         f"LID field {index + 1} ({token}) is invalid. "
                         f"Fields must only consist of lowercase letters, digits, "
-                        f"hyphens (-), underscores (_) or periods (.)"
+                        f"hyphens (-), underscores (_) or periods (.), per PDS SR Sec. 6D.2"
                     )
 
-            # Finally, make sure the VID conforms to a version number
+            # Make sure the VID conforms to a version number
             version_regex = re.compile(r"^\d+\.\d+$")
 
             if vid and not version_regex.fullmatch(vid):
                 raise InvalidIdentifierException(
                     f"Parsed VID ({vid}) does not conform to a valid version identifier. "
                     "Version identifier must consist only of a major and minor version "
-                    "joined with a period (ex: 1.0)"
+                    "joined with a period (ex: 1.0), per PDS SR Sec. 6D.3"
+                )
+
+            # Finally, ensure the whole identifier conforms to the length constraint
+            identifier_max_length = 255
+            if not len(doi.pds_identifier) <= identifier_max_length:
+                raise InvalidIdentifierException(
+                    f"LIDVID {doi.pds_identifier} does not conform to PDS identifier max length constraint "
+                    f"({identifier_max_length}), per SR Sec. 6D"
                 )
         except InvalidIdentifierException as err:
             raise InvalidIdentifierException(

--- a/src/pds_doi_service/core/outputs/doi_validator.py
+++ b/src/pds_doi_service/core/outputs/doi_validator.py
@@ -387,7 +387,7 @@ class DOIValidator:
             if not len(doi.pds_identifier) <= identifier_max_length:
                 raise InvalidIdentifierException(
                     f"LIDVID {doi.pds_identifier} does not conform to PDS identifier max length constraint "
-                    f"({identifier_max_length}), per SR Sec. 6D"
+                    f"({identifier_max_length}), per PDS SR Sec. 6D"
                 )
         except InvalidIdentifierException as err:
             raise InvalidIdentifierException(

--- a/src/pds_doi_service/core/outputs/doi_validator.py
+++ b/src/pds_doi_service/core/outputs/doi_validator.py
@@ -361,15 +361,14 @@ class DOIValidator:
                 )
 
             # Now check each field for the expected set of characters
-            token_regex = re.compile(r"[a-z0-9][a-z0-9-._]{0,31}")
+            token_regex = re.compile(r"[a-z0-9-._]*")
 
             for index, token in enumerate(lid_tokens):
                 if not token_regex.fullmatch(token):
                     raise InvalidIdentifierException(
-                        f"LIDVID field {index + 1} ({token}) is invalid. "
-                        f"Fields must begin with a letter or digit, and only "
-                        f"consist of letters, digits, hyphens (-), underscores (_) "
-                        f"or periods (.)"
+                        f"LID field {index + 1} ({token}) is invalid. "
+                        f"Fields must only consist of lowercase letters, digits, "
+                        f"hyphens (-), underscores (_) or periods (.)"
                     )
 
             # Finally, make sure the VID conforms to a version number

--- a/src/pds_doi_service/core/outputs/doi_validator.py
+++ b/src/pds_doi_service/core/outputs/doi_validator.py
@@ -347,9 +347,10 @@ class DOIValidator:
         lid_tokens = lid.split(":")
 
         try:
-            # Make sure we got a URN
-            if lid_tokens[0] != "urn":
-                raise InvalidIdentifierException('LIDVID must start with "urn"')
+            # Make sure the prescribed static fields are correct
+            required_prefix_elements = ["urn", "nasa", "pds"]
+            if lid_tokens[:3] != required_prefix_elements:
+                raise InvalidIdentifierException(f"LIDVID must start with elements {required_prefix_elements}")
 
             # Make sure we got the minimum number of fields, and that
             # the number of fields is consistent with the product type

--- a/src/pds_doi_service/core/outputs/test/doi_validator_test.py
+++ b/src/pds_doi_service/core/outputs/test/doi_validator_test.py
@@ -294,6 +294,26 @@ class DoiValidatorTest(unittest.TestCase):
         with self.assertRaises(InvalidRecordException):
             self._doi_validator._check_identifier_fields(doi_obj)
 
+    def test_identifier_validation_valid_lidvid(self):
+        """
+        Test validation of DOI object with various valid LIDVIDs
+        Expecting no errors
+        """
+        doi_obj = Doi(
+            title=self.title + " different",
+            publication_date=self.transaction_date,
+            product_type=self.product_type,
+            product_type_specific=self.product_type_specific,
+            pds_identifier="",
+            status=DoiStatus.Draft,
+        )
+
+        # Test max valid identifier length
+        partial_id = "urn:nasa:pds:lab_shocked_feldspars"
+        doi_obj.pds_identifier = f"{partial_id}{'a'*(255 - len(partial_id))}"
+
+        self._doi_validator._check_lidvid_field(doi_obj)
+
     def test_identifier_validation_invalid_lidvid(self):
         """
         Test validation of Doi object with various invalid LIDVIDs.
@@ -326,8 +346,8 @@ class DoiValidatorTest(unittest.TestCase):
         with self.assertRaises(InvalidIdentifierException):
             self._doi_validator._check_lidvid_field(doi_obj)
 
-        # Test invalid field tokens (invalid characters)
-        doi_obj.pds_identifier = "urn:nasa:_pds:lab_shocked_feldspars"
+        # Test invalid field tokens (invalid mandatory values)
+        doi_obj.pds_identifier = "urn:nasa:not_pds:lab_shocked_feldspars"
 
         with self.assertRaises(InvalidIdentifierException):
             self._doi_validator._check_lidvid_field(doi_obj)

--- a/src/pds_doi_service/core/outputs/test/doi_validator_test.py
+++ b/src/pds_doi_service/core/outputs/test/doi_validator_test.py
@@ -347,6 +347,16 @@ class DoiValidatorTest(unittest.TestCase):
             self._doi_validator._check_lidvid_field(doi_obj)
 
         # Test invalid field tokens (invalid mandatory values)
+        doi_obj.pds_identifier = "not_urn:nasa:pds:lab_shocked_feldspars"
+
+        with self.assertRaises(InvalidIdentifierException):
+            self._doi_validator._check_lidvid_field(doi_obj)
+
+        doi_obj.pds_identifier = "urn:not_nasa:pds:lab_shocked_feldspars"
+
+        with self.assertRaises(InvalidIdentifierException):
+            self._doi_validator._check_lidvid_field(doi_obj)
+
         doi_obj.pds_identifier = "urn:nasa:not_pds:lab_shocked_feldspars"
 
         with self.assertRaises(InvalidIdentifierException):

--- a/src/pds_doi_service/core/outputs/test/doi_validator_test.py
+++ b/src/pds_doi_service/core/outputs/test/doi_validator_test.py
@@ -343,6 +343,13 @@ class DoiValidatorTest(unittest.TestCase):
         with self.assertRaises(InvalidIdentifierException):
             self._doi_validator._check_lidvid_field(doi_obj)
 
+        # Test invalid identifier length
+        partial_id = "urn:nasa:pds:lab_shocked_feldspars"
+        doi_obj.pds_identifier = f"{partial_id}{'a'*(256 - len(partial_id))}"
+
+        with self.assertRaises(InvalidIdentifierException):
+            self._doi_validator._check_lidvid_field(doi_obj)
+
     def test_identifier_validation_doi_id_mismatch(self):
         """
         Test validation of Doi with inconsistent doi and id fields.


### PR DESCRIPTION
## 🗒️ Summary
Applies minor fixes to LIDVID validation logic and related exception messages.  Adds tests for new/changed validation elements.

## ⚙️ Test Data and/or Report
Unit tests pass (except linting, which failed prior to changes)
Behavioural tests unable to be run per #352 

## ♻️ Related Issues
fixes #336 


