### PR TITLE
Issue #350

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,9 @@
+import os
+import pathlib
+
+
+def parse_project_root_dir() -> str:
+    return str(pathlib.Path(os.path.abspath(__file__)).parent.parent)
+
+
+PROJECT_ROOT_DIR = parse_project_root_dir()

--- a/src/pds_doi_service/core/actions/reserve.py
+++ b/src/pds_doi_service/core/actions/reserve.py
@@ -281,6 +281,12 @@ class DOICoreActionReserve(DOICoreAction):
             raise err
         # Convert all other errors into a CriticalDOIException to report back
         except Exception as err:
+            error_message = str(err)
+            bad_credentials_error_substr = "reason: 404 Client Error"
+            if bad_credentials_error_substr in error_message:
+                explanatory_message = "This error may also be indicative of bad credentials when returned by DataCite."
+                raise CriticalDOIException(f"{error_message}.  {explanatory_message}")
+
             raise CriticalDOIException(err)
 
         # Create the return output label containing records for all submitted DOI's

--- a/src/pds_doi_service/core/actions/update.py
+++ b/src/pds_doi_service/core/actions/update.py
@@ -16,7 +16,6 @@ from pds_doi_service.core.actions.list import DOICoreActionList
 from pds_doi_service.core.entities.doi import Doi
 from pds_doi_service.core.entities.doi import DoiStatus
 from pds_doi_service.core.entities.exceptions import collect_exception_classes_and_messages
-from pds_doi_service.core.entities.exceptions import UnknownIdentifierException
 from pds_doi_service.core.entities.exceptions import CriticalDOIException
 from pds_doi_service.core.entities.exceptions import DuplicatedTitleDOIException
 from pds_doi_service.core.entities.exceptions import InputFormatException
@@ -24,6 +23,7 @@ from pds_doi_service.core.entities.exceptions import InvalidIdentifierException
 from pds_doi_service.core.entities.exceptions import raise_or_warn_exceptions
 from pds_doi_service.core.entities.exceptions import TitleDoesNotMatchProductTypeException
 from pds_doi_service.core.entities.exceptions import UnexpectedDOIActionException
+from pds_doi_service.core.entities.exceptions import UnknownIdentifierException
 from pds_doi_service.core.entities.exceptions import WarningDOIException
 from pds_doi_service.core.input.input_util import DOIInputUtil
 from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_JSON
@@ -281,7 +281,6 @@ class DOICoreActionUpdate(DOICoreAction):
         existing_dois, _ = self._web_parser.parse_dois_from_label(existing_doi_label)
 
         return existing_dois[0]
-
 
     def _validate_dois(self, dois):
         """

--- a/src/pds_doi_service/core/util/config_parser.py
+++ b/src/pds_doi_service/core/util/config_parser.py
@@ -14,7 +14,6 @@ core DOI service.
 """
 import configparser
 import functools
-import logging
 import os
 import sys
 from os.path import abspath
@@ -24,6 +23,9 @@ from os.path import join
 from pkg_resources import resource_filename
 
 from projectdefinitions import PROJECT_ROOT_DIR
+from pds_doi_service.core.util.logging import get_logger
+
+logger = get_logger()
 
 
 class DOIConfigParser(configparser.ConfigParser):
@@ -74,8 +76,6 @@ class DOIConfigUtil:
     @staticmethod
     @functools.lru_cache()
     def get_config():
-        logger = logging.getLogger(__name__)
-
         parser = DOIConfigParser()
 
         # default configuration

--- a/src/pds_doi_service/core/util/config_parser.py
+++ b/src/pds_doi_service/core/util/config_parser.py
@@ -79,32 +79,34 @@ class DOIConfigUtil:
         parser = DOIConfigParser()
 
         # default configuration
-        conf_default = "conf.ini.default"
-        conf_default_path = resource_filename(__name__, conf_default)
+        default_config_filename = "conf.ini.default"
+        default_config_filepath = resource_filename(__name__, default_config_filename)
 
         # user-specified configuration for production
-        conf_user = "pds_doi_service.ini"
-        conf_user_prod_path = os.path.join(PROJECT_ROOT_DIR, conf_user)
+        user_defined_config_filename = "pds_doi_service.ini"
+        user_defined_config_filepath = os.path.join(PROJECT_ROOT_DIR, user_defined_config_filename)
 
         # user-specified configuration for development
-        conf_user_dev_path = abspath(join(dirname(__file__), os.pardir, os.pardir, os.pardir, conf_user))
+        dev_config_filename = "pds_doi_service.ini"
+        dev_config_filepath = abspath(join(dirname(__file__), os.pardir, os.pardir, os.pardir, dev_config_filename))
 
-        candidates_full_path = [conf_default_path, conf_user_prod_path, conf_user_dev_path]
+        # Parsed in order, with subsequent config values overwriting values provided in preceding configs
+        config_candidate_filepaths = [default_config_filepath, user_defined_config_filepath, dev_config_filepath]
 
-        logger.info("Searching for configuration files in %s", candidates_full_path)
-        found = parser.read(candidates_full_path)
+        logger.info("Searching for configuration files from candidates %s", config_candidate_filepaths)
+        found = parser.read(config_candidate_filepaths)
 
         if not found:
             raise RuntimeError(
                 "Could not find an INI configuration file to "
-                f"parse from the following candidates: {candidates_full_path}"
+                f"parse from the following candidates: {config_candidate_filepaths}"
             )
 
         # When providing multiple configs they are parsed in successive order,
         # and any previously parsed values are overwritten. So the config
         # we use should correspond to the last file in the list returned
         # from ConfigParser.read()
-        logger.info("Using the following configuration file: %s", found[-1])
+        logger.info("Using configs (with later files overwriting previous files' values): %s", found)
         parser = DOIConfigUtil._resolve_relative_path(parser)
 
         return parser

--- a/src/pds_doi_service/core/util/config_parser.py
+++ b/src/pds_doi_service/core/util/config_parser.py
@@ -23,6 +23,8 @@ from os.path import join
 
 from pkg_resources import resource_filename
 
+from projectdefinitions import PROJECT_ROOT_DIR
+
 
 class DOIConfigParser(configparser.ConfigParser):
     """
@@ -82,7 +84,7 @@ class DOIConfigUtil:
 
         # user-specified configuration for production
         conf_user = "pds_doi_service.ini"
-        conf_user_prod_path = os.path.join(sys.prefix, conf_user)
+        conf_user_prod_path = os.path.join(PROJECT_ROOT_DIR, conf_user)
 
         # user-specified configuration for development
         conf_user_dev_path = abspath(join(dirname(__file__), os.pardir, os.pardir, os.pardir, conf_user))

--- a/src/pds_doi_service/core/util/config_parser.py
+++ b/src/pds_doi_service/core/util/config_parser.py
@@ -20,10 +20,9 @@ from os.path import abspath
 from os.path import dirname
 from os.path import join
 
-from pkg_resources import resource_filename
-
-from projectdefinitions import PROJECT_ROOT_DIR
+from constants import PROJECT_ROOT_DIR
 from pds_doi_service.core.util.logging import get_logger
+from pkg_resources import resource_filename
 
 logger = get_logger()
 

--- a/src/pds_doi_service/core/util/general_util.py
+++ b/src/pds_doi_service/core/util/general_util.py
@@ -21,6 +21,7 @@ from urllib.parse import unquote
 from urllib.parse import urlparse
 
 from pds_doi_service.core.util.config_parser import DOIConfigUtil
+from pds_doi_service.core.util.logging import get_logger as _get_logger
 
 PDS3_URL_TEMPLATE = "https://pds.nasa.gov/ds-view/pds/viewDataset.jsp?dsid={identifier}"
 """The landing page URL template for PDS3 datasets"""
@@ -72,20 +73,9 @@ def get_logger(module_name=None):
         The logger object.
 
     """
-    if module_name:
-        _logger = logging.getLogger(module_name)
-    else:
-        _logger = logging.getLogger(__name__)
-
-    my_format = "%(levelname)s %(name)s:%(funcName)s %(message)s"
-
-    logging.basicConfig(format=my_format, filemode="a")
-
     config = DOIConfigUtil().get_config()
     logging_level = config.get("OTHER", "logging_level")
-    _logger.setLevel(getattr(logging, logging_level.upper()))
-
-    return _logger
+    return _get_logger(name=module_name, logging_level=logging_level)
 
 
 logger = get_logger(__name__)

--- a/src/pds_doi_service/core/util/logging.py
+++ b/src/pds_doi_service/core/util/logging.py
@@ -1,0 +1,37 @@
+import logging
+
+
+def get_logger(name: str = None, logging_level: int = logging.INFO):
+    """
+    Creates and returns a logging object for the provided module name. The
+    logger is configured according to the settings of the INI config.
+
+    Notes
+    -----
+    This function should be defined first in this module, so we can
+    use it to define a logger object for use with the other general_util
+    functions.
+
+    Parameters
+    ----------
+    name : str, optional
+        If provided, the name to create logger for. Defaults to the name of the current module.
+    log_level: int, optional
+        If provided, the logging level.  Defaults to INFO
+
+    Returns
+    -------
+    logger : logging.logger
+        The logger object.
+
+    """
+    if name is not None:
+        _logger = logging.getLogger(name)
+    else:
+        _logger = logging.getLogger(__name__)
+
+    log_format = "%(levelname)s %(name)s:%(funcName)s %(message)s"
+    logging.basicConfig(format=log_format, filemode="a")
+    _logger.setLevel(logging_level)
+
+    return _logger


### PR DESCRIPTION
## 🗒️ Summary
Resolves #350 (probably - given the fact that I was able to replicate @tloubrieu-jpl's experience with a fresh development environment and the fact that the error should have affected anyone using a venv and a user-defined config, I'm gonna guess this is the cause).

The path to the user-defined config at the project/repository root was incorrectly being resolved via `sys.prefix` (which is something like `path/to/doi-service/venv` when a venv is in use), and a logging bug was hiding the fact that the user-defined config was not being found/used.

This PR also fixes the logging bug, adds some explanatory context to the 404 response returned by DataCite, and improves the articulation of some comments and symbols.

## ⚙️ Test Data and/or Report
Unit tests pass (except `flake8` lint)

## ♻️ Related Issues
closes #350 


