### PR TITLE
Pin pandas and update openpyxl version

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Testing details are detailed in this section.
 
 ### Tox (for developers)
 
+#### N.B. Updates to pip dependencies are not automatically applied to existing tox virtual environments, to keep unit testing fast.  The simplest way to propagate dependency updates is to delete `./.tox` and run tox again.
+
 [tox](https://tox.readthedocs.io/) is installed automatically during `pip install --editable .[dev]`, and provides virtual environments and run configurations for
 - unit/functional testing
 - linting

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,8 @@ install_requires =
     nltk==3.5
     numpy>=1.18
     openapi-schema-validator==0.1.4
-    openpyxl==3.0.3
-    pandas>=1.0
+    openpyxl~=3.0
+    pandas~=1.0
     python-dateutil>=2.8
     python-jose[cryptography]
     pytz==2020.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     numpy>=1.18
     openapi-schema-validator==0.1.4
     openpyxl~=3.0
-    pandas~=1.0
+    pandas~=1.4
     python-dateutil>=2.8
     python-jose[cryptography]
     pytz==2020.1


### PR DESCRIPTION
## 🗒️ Summary
Automatic `pandas` update resulted in failure due to too-low version of `openpyxl`.

 - pins `pandas` to prevent reoccurrence
 - updates `openpyxl`
 - adds to doco

## ⚙️ Test Data and/or Report
Passes unit tests

Closes #368 