### PR TITLE
set branch testing to run in environment

### DIFF
--- a/.github/workflows/branch-cicd.yaml
+++ b/.github/workflows/branch-cicd.yaml
@@ -28,6 +28,7 @@ jobs:
     branch-testing:
         name: 🪵 Branch Testing
         runs-on: ubuntu-latest
+        environment: branch-integration-testing
         if: github.actor != 'pdsen-ci'
 
         steps:
@@ -54,19 +55,6 @@ jobs:
                     key: pds-${{runner.os}}-py-${{hashFiles('**/*.whl')}}
                     # To restore a set of files, we only need to match a prefix of the saved key.
                     restore-keys: pds-${{runner.os}}-py-
-            -
-                name: Update default configuration
-                run: |
-                    import sys
-                    import os
-                    print("Running python version {}".format(sys.version))
-                    conf_file = "pds_doi_service.ini"
-                    print("Create config file for unit test {}".format(conf_file))
-                    with open(conf_file, "w") as f:
-                        f.write("[OSTI]\n")
-                        f.write("user = {}\n".format("${{secrets.osti_login}}"))
-                        f.write("password = {}\n".format("${{secrets.osti_password}}"))
-                shell: python
             -
                 name: 🩺 Test Software
                 run:


### PR DESCRIPTION
to allow passing DataCite and other secrets to GitHub Action

## 🗒️ Summary
Sets branch testing action to run in newly-instantiated `branch-integration-testing` environment, which has been set up with DataCite secrets.

Removes obsolete OSTI configuration patching step.

