### PR TITLE
fix bulk-update notebook variable naming to reflect actual contents

### DIFF
--- a/src/pds_doi_service/notebooks/Bulk Record Update.ipynb
+++ b/src/pds_doi_service/notebooks/Bulk Record Update.ipynb
@@ -70,7 +70,7 @@
     "# TODO: assign these fields as necessary to query for the group of DOI records to be updated\n",
     "\n",
     "# DOI ID's to match\n",
-    "dois        = []\n",
+    "doi_ids        = []\n",
     "\n",
     "# PDS ID's (PDS3 or LID/LIDVID) to match\n",
     "identifiers = []\n",
@@ -113,7 +113,7 @@
     "\n",
     "list_action_kwargs = {\n",
     "    \"format\"       : \"label\",\n",
-    "    \"doi\"          : \",\".join(dois),\n",
+    "    \"doi\"          : \",\".join(doi_ids),\n",
     "    \"ids\"          : \",\".join(identifiers),\n",
     "    \"node\"         : \",\".join(nodes),\n",
     "    \"status\"       : \",\".join(status),\n",
@@ -125,8 +125,9 @@
     "query_label = list_action.run(**list_action_kwargs)\n",
     "\n",
     "if query_label:\n",
-    "    doi_records, _ = DOIDataCiteWebParser.parse_dois_from_label(query_label)\n",
-    "    print(f\"Obtained {len(doi_records)} record(s) from provided query.\")\n",
+    "    dois, _ = DOIDataCiteWebParser.parse_dois_from_label(query_label)\n",
+    "    dois_count = len(dois)\n",
+    "    print(f\"Obtained {dois_count} DOI{'' if dois_count == 1 else 's'} from provided query.\")\n",
     "else:\n",
     "    print(\"Provided query returned no results.\")"
    ]
@@ -183,9 +184,9 @@
    "source": [
     "## Perform Bulk Update(s) In Memory\n",
     "\n",
-    "The DOI records matching the query parameters have now been parsed and read into memory within the `doi_records` list.\n",
+    "The DOI records matching the query parameters have now been parsed to `Doi` objects and stored in memory (`dois`).\n",
     "\n",
-    "The cells below may be used to make whatever updates are necessary to the records in memory. Any records to be updated should be assigned to the list `updated_doi_records`. If you plan to manually update the label returned from the query, you may skip to the **Commit Updated Label to Local Transaction Database** step. The path to the modified label should be provided for `updated_record_label_path`."
+    "The cells below may be used to make whatever updates are necessary to the DOIs in memory. Any DOIs to be updated should be assigned to the list `updated_dois`. If you plan to manually update the label returned from the query, you may skip to the **Commit Updated Label to Local Transaction Database** step. The path to the modified label should be provided for `updated_record_label_path`."
    ]
   },
   {
@@ -195,24 +196,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "updated_doi_records = []\n",
+    "updated_dois = []\n",
     "\n",
-    "for doi_record in doi_records:\n",
-    "    # TODO: provide logic to update the current doi_record\n",
-    "    # ex: doi_record.publisher = \"NASA Planetary Data System\"\n",
+    "for doi in dois:\n",
+    "    # TODO: provide logic to update the current doi\n",
+    "    # ex: doi.publisher = \"NASA Planetary Data System\"\n",
     "        \n",
     "    # The following lines ensure that any records processed that are in the\n",
     "    # Draft or Registered state are kept in the Draft/Registered state after submission\n",
     "    # to DataCite. This can be useful for preventing records from being moved to\n",
     "    # the Findable state prematurely.\n",
-    "    if doi_record.status == DoiStatus.Registered:\n",
-    "        doi_record.event = DoiEvent.Register\n",
-    "    elif doi_record.status == DoiStatus.Draft:\n",
-    "        doi_record.event = DoiEvent.Hide\n",
+    "    if doi.status == DoiStatus.Registered:\n",
+    "        doi.event = DoiEvent.Register\n",
+    "    elif doi.status == DoiStatus.Draft:\n",
+    "        doi.event = DoiEvent.Hide\n",
     "\n",
-    "    updated_doi_records.append(doi_record)\n",
+    "    updated_dois.append(doi)\n",
     "    \n",
-    "updated_record_label = DOIDataCiteRecord().create_doi_record(updated_doi_records)"
+    "updated_record_label = DOIDataCiteRecord().create_doi_record(updated_dois)"
    ]
   },
   {
@@ -222,7 +223,7 @@
    "source": [
     "## Check Updated Label\n",
     "\n",
-    "Run the following cell to output the contents of the label created from the DOI records updated in-memory."
+    "Run the following cell to output the contents of the label created from the DOIs updated in-memory."
    ]
   },
   {


### PR DESCRIPTION
## 🗒️ Summary
Bulk Record Update erroneously refers to the collection of Doi objects parsed from DataCite as doi_records. Given that a different class DoiRecord also exists within doi-service, and especially given the way methods/attributes are sometimes generated dynamically from strings (which breaks code insight), this is a potential source of confusion and wasted time for new users of the notebook.

This PR renames some variables and amends some documentation text.

## ⚙️ Test Data and/or Report
n/a

## ♻️ Related Issues
closes #374 


