### PR TITLE
#377 author list parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,28 @@ $ tox -e docs  # Build the documentation to see if that works
 
 It is strongly recommended to add `tox -e lint` to your `pre-commit` [git hook](https://www.atlassian.com/git/tutorials/git-hooks), and `tox -e tests` in a `pre-push` hook, as only linted and test-passing PRs will be merged.
 
+The following linting example is provided for ease of use:
+
+```bash
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep ".py$")
+
+echo "Linting files"
+tox -e lint
+git add $STAGED_FILES  # add any lint-related changes to the current commit
+
+if [ $? -ne 0 ]
+then
+    echo "Initial lint detected errors, re-linting to determine whether errors remain"
+    tox -e lint
+    if [ $? -ne 0 ]
+    then
+      exit 1
+    fi
+fi
+
+exit 0
+```
+
 You can also run `pytest`, `sphinx-build`, `mypy`, etc., if that's more your speed.
 
 

--- a/src/pds_doi_service/api/test/data/bundle_in.xml
+++ b/src/pds_doi_service/api/test/data/bundle_in.xml
@@ -8,7 +8,7 @@
 <information_model_version>1.11.1.0</information_model_version>
 <product_class>Product_Bundle</product_class>
 <Citation_Information>
-<author_list>R. Deen, H. Abarca, P. Zamani, J.Maki</author_list>
+<author_list>R. Deen, H. Abarca, P. Zamani, J. Maki</author_list>
 <publication_year>2019</publication_year>
 <description>
 InSight Cameras Experiment Data Record (EDR) and Reduced Data Record (RDR) Data Products

--- a/src/pds_doi_service/api/test/data/bundle_in_with_contributors.xml
+++ b/src/pds_doi_service/api/test/data/bundle_in_with_contributors.xml
@@ -8,7 +8,7 @@
 <information_model_version>1.11.1.0</information_model_version>
 <product_class>Product_Bundle</product_class>
 <Citation_Information>
-<author_list>R. Deen, H. Abarca, P. Zamani, J.Maki</author_list>
+<author_list>R. Deen, H. Abarca, P. Zamani, J. Maki</author_list>
 
 
 <!-- <editor_list>Williams, D.R.; McLaughlin, S.A.</editor_list> -->

--- a/src/pds_doi_service/core/actions/test/data/pds4_bundle.xml
+++ b/src/pds_doi_service/core/actions/test/data/pds4_bundle.xml
@@ -8,7 +8,7 @@
         <information_model_version>1.11.1.0</information_model_version>
         <product_class>Product_Bundle</product_class>
         <Citation_Information>
-            <author_list>R. Deen, H. Abarca, P. Zamani, J.Maki</author_list>
+            <author_list>R. Deen, H. Abarca, P. Zamani, J. Maki</author_list>
             <publication_year>2019</publication_year>
             <description>
                 InSight Cameras Experiment Data Record (EDR) and Reduced Data Record (RDR) Data Products

--- a/src/pds_doi_service/core/actions/test/data/pds4_bundle_with_contributors.xml
+++ b/src/pds_doi_service/core/actions/test/data/pds4_bundle_with_contributors.xml
@@ -8,7 +8,7 @@
         <information_model_version>1.11.1.0</information_model_version>
         <product_class>Product_Bundle</product_class>
         <Citation_Information>
-            <author_list>R. Deen, H. Abarca, P. Zamani, J.Maki</author_list>
+            <author_list>R. Deen, H. Abarca, P. Zamani, J. Maki</author_list>
             <editor_list>Smith, P. H.; Lemmon, M.; Beebe, R. F.</editor_list>
             <publication_year>2019</publication_year>
             <description>

--- a/src/pds_doi_service/core/actions/test/data/pds4_bundle_with_doi_and_contributors.xml
+++ b/src/pds_doi_service/core/actions/test/data/pds4_bundle_with_doi_and_contributors.xml
@@ -9,7 +9,7 @@
         <product_class>Product_Bundle</product_class>
         <Citation_Information>
             <doi>10.17189/29569</doi>
-            <author_list>R. Deen, H. Abarca, P. Zamani, J.Maki</author_list>
+            <author_list>R. Deen, H. Abarca, P. Zamani, J. Maki</author_list>
             <editor_list>Smith, P. H.; Lemmon, M.; Beebe, R. F.</editor_list>
             <publication_year>2019</publication_year>
             <description>

--- a/src/pds_doi_service/core/db/test/data/pds4_bundle.xml
+++ b/src/pds_doi_service/core/db/test/data/pds4_bundle.xml
@@ -8,7 +8,7 @@
         <information_model_version>1.11.1.0</information_model_version>
         <product_class>Product_Bundle</product_class>
         <Citation_Information>
-            <author_list>R. Deen, H. Abarca, P. Zamani, J.Maki</author_list>
+            <author_list>R. Deen, H. Abarca, P. Zamani, J. Maki</author_list>
             <publication_year>2019</publication_year>
             <description>
                 InSight Cameras Experiment Data Record (EDR) and Reduced Data Record (RDR) Data Products

--- a/src/pds_doi_service/core/input/pds4_util.py
+++ b/src/pds_doi_service/core/input/pds4_util.py
@@ -404,8 +404,9 @@ class DOIPDS4LabelUtil:
 
                 break
 
+        # In practice, this default should never be reached, as it requires a mononym WITH a separator, like "somename,"
         if not entity:
-            entity = {"full_name": full_name, "affiliation": [], "name_type": "Personal"}
+            entity = {"name": full_name, "affiliation": [], "name_type": "Personal"}
 
         logger.debug(f"parsed person {entity}")
 

--- a/src/pds_doi_service/core/input/pds4_util.py
+++ b/src/pds_doi_service/core/input/pds4_util.py
@@ -362,6 +362,19 @@ class DOIPDS4LabelUtil:
 
         full_name = full_name.strip()
 
+        # Detect organization names, which lack separable chunks
+        if not any([sep in full_name for sep in first_last_name_separators]):
+            entity = {
+                "name": full_name,
+                "affiliation": [
+                    full_name,
+                ],
+                "name_type": "Organization",
+            }
+
+            logger.debug(f"parsed organization {entity}")
+            return entity
+
         entity = None
 
         for sep in first_last_name_separators:

--- a/src/pds_doi_service/core/input/pds4_util.py
+++ b/src/pds_doi_service/core/input/pds4_util.py
@@ -412,19 +412,33 @@ class DOIPDS4LabelUtil:
 
         return entity
 
-    def get_names(self, name_list, first_last_name_order=(0, -1), first_last_name_separator=(",", ".")):
+    def get_names(
+        self,
+        name_list: List[str],
+        first_last_name_order: Tuple[int, int] = (0, -1),
+        first_last_name_separators: Tuple[str] = (",", "."),
+    ) -> List[Dict[str, Union[str, List[str]]]]:
+        """
+        Given a list of personal/organizational name strings and some parsing configuration, return a list of Dicts
+        representing the named entities.
+        :param name_list: a list of raw name strings to parse
+        :param first_last_name_order: a tuple of indices by which to identify the first and last name chunks, respectively
+        :param first_last_name_separators: a tuple of chars by which to split the full_name into a first and last name chunk
+        :returns: a List of parsed entities
+        :rtype: List[Dict[str, Union[str, List[str]]]]
+        """
         logger.debug(f"name_list {name_list}")
         logger.debug(f"first_last_name_order {first_last_name_order}")
 
         persons = []
 
         for full_name in name_list:
-            persons.append(self._get_name_components(full_name, first_last_name_order, first_last_name_separator))
+            persons.append(self._get_name_components(full_name, first_last_name_order, first_last_name_separators))
 
         return persons
 
-    def get_author_names(self, name_list: List[str]) -> List:
+    def get_author_names(self, name_list: List[str]) -> List[Dict[str, Union[str, List[str]]]]:
         return self.get_names(name_list, first_last_name_order=(-1, 0))
 
     def get_editor_names(self, name_list):
-        return self.get_names(name_list, first_last_name_separator=(",",))
+        return self.get_names(name_list, first_last_name_separators=(",",))

--- a/src/pds_doi_service/core/input/pds4_util.py
+++ b/src/pds_doi_service/core/input/pds4_util.py
@@ -358,18 +358,25 @@ class DOIPDS4LabelUtil:
         :returns: the parsed entity
         :rtype: Dict[str, Union[str, List[str]]]
         """
+
+        # helper function to encapsulate logic for detecting organizational names
+        def name_str_is_organization(separators: Tuple[str], name: str) -> bool:
+            is_mononym = not any([sep in name for sep in separators])
+            has_trailing_period = name[-1] == "."
+            return is_mononym or has_trailing_period
+
         logger.debug(f"parse full_name {full_name}")
 
         full_name = full_name.strip()
 
         # Detect organization names, which lack separable chunks
-        if not any([sep in full_name for sep in first_last_name_separators]):
+        if name_str_is_organization(first_last_name_separators, full_name):
             entity = {
                 "name": full_name,
                 "affiliation": [
                     full_name,
                 ],
-                "name_type": "Organization",
+                "name_type": "Organizational",
             }
 
             logger.debug(f"parsed organization {entity}")
@@ -390,6 +397,7 @@ class DOIPDS4LabelUtil:
                     first_i, last_i = tuple(first_last_name_order)
 
                 # re-add . if it has been removed as a separator
+                # it's unclear why this is being appended - this should be clarified
                 first_name_suffix = "." if sep == "." else ""
 
                 entity = {

--- a/src/pds_doi_service/core/input/pds4_util.py
+++ b/src/pds_doi_service/core/input/pds4_util.py
@@ -16,7 +16,7 @@ from datetime import timezone
 from enum import Enum
 from typing import Dict
 from typing import List
-from typing import Tuple
+from typing import Sequence
 from typing import Union
 
 from pds_doi_service.core.entities.doi import Doi
@@ -109,9 +109,9 @@ class DOIPDS4LabelUtil:
 
     def _check_for_possible_full_name(self, names_list):
         # Given a list of names:
-        # Case 1: "R. Deen, H. Abarca, P. Zamani, J.Maki"
+        # Case 1: "R. Deen, H. Abarca, P. Zamani, J. Maki"
         # determine if each token can be potentially a person' name:
-        #   "R. Deen", "H. Abarca", "J.Maki"
+        #   "R. Deen", "H. Abarca", "J. Maki"
         # This happens very rarely but it does happen.
         # Case 4 :"VanBommel, S. J., Guinness, E., Stein, T., and the MER Science Team"
         o_list_contains_full_name_flag = False
@@ -124,7 +124,7 @@ class DOIPDS4LabelUtil:
                 # Now that the dot is found, look to see the name contains at
                 # least two tokens.
                 if len(one_name.strip().split(".")) >= 2:
-                    # 'R. Deen' split to ['R','Deen'], "J.Maki" split to ['J','Maki']
+                    # 'R. Deen' split to ['R','Deen'], "J. Maki" split to ['J','Maki']
                     num_person_names += 1
             else:
                 # The name does not contain a dot, split using spaces.
@@ -157,7 +157,7 @@ class DOIPDS4LabelUtil:
             Case 1 --> Should be parsed by semi-colon
                 pds4_fields_authors = "Lemmon, M."
             Case 2 --> Should be parsed by comma
-                pds4_fields_authors = "R. Deen, H. Abarca, P. Zamani, J.Maki"
+                pds4_fields_authors = "R. Deen, H. Abarca, P. Zamani, J. Maki"
             Case 3 --> Should be parsed by semi-colon
                 pds4_fields_authors = "Davies, A.; Veeder, G."
             Case 4  --> Should be parsed by semi-colon
@@ -183,7 +183,7 @@ class DOIPDS4LabelUtil:
         authors_from_semi_colon_split = pds4_fields_authors.split(";")
 
         # Check from authors_from_comma_split to see if it possibly contains full name.
-        # Mostly this case: "R. Deen, H. Abarca, P. Zamani, J.Maki"
+        # Mostly this case: "R. Deen, H. Abarca, P. Zamani, J. Maki"
         # When it is not obvious because it looks similarly to this case:
         # "VanBommel, S. J., Guinness, E., Stein, T., and the MER Science Team"
         comma_parsed_list_contains_full_name = self._check_for_possible_full_name(authors_from_comma_split)
@@ -345,32 +345,25 @@ class DOIPDS4LabelUtil:
     @staticmethod
     def _get_name_components(
         full_name: str,
-        first_last_name_order: Tuple[int, int],
-        first_last_name_separators: Tuple[str],
-        use_smart_first_name_detector: bool = True,
-    ) -> Dict[str, Union[str, List[str]]]:
+    ) -> Dict[str, Union[str, Sequence[str]]]:
         """
         Given a raw full_name string and some splitting configuration, return a dict describing the named entity
         :param full_name: a raw full-name string to parse
-        :param first_last_name_order: a tuple of indices by which to identify the first and last name chunks, respectively
-        :param first_last_name_separators: a tuple of chars by which to split the full_name into a first and last name chunk
-        :param use_smart_first_name_detector: use an automatic first/last splitting algorithm
         :returns: the parsed entity
         :rtype: Dict[str, Union[str, List[str]]]
         """
 
         # helper function to encapsulate logic for detecting organizational names
-        def name_str_is_organization(separators: Tuple[str], name: str) -> bool:
+        def name_str_is_organization(separators: List[str], name: str) -> bool:
             is_mononym = not any([sep in name for sep in separators])
-            has_trailing_period = name[-1] == "."
-            return is_mononym or has_trailing_period
+            return is_mononym
 
-        logger.debug(f"parse full_name {full_name}")
-
-        full_name = full_name.strip()
+        # An ordered tuple of chars by which to split full_name into name chunks, with earlier elements taking
+        # precedence at each stage of splitting (last/given, then first/middle)
+        primary_separators = [",", ". "]
 
         # Detect organization names, which lack separable chunks
-        if name_str_is_organization(first_last_name_separators, full_name):
+        if name_str_is_organization(primary_separators, full_name):
             entity = {
                 "name": full_name,
                 "affiliation": [
@@ -382,71 +375,64 @@ class DOIPDS4LabelUtil:
             logger.debug(f"parsed organization {entity}")
             return entity
 
-        entity = None
+        # Perform primary split, intuiting last/given name order from the separator
+        primary_separators_present_in_full_name = [sep for sep in primary_separators if sep in full_name]
+        primary_separator = primary_separators_present_in_full_name[0]
+        comma_separated = "," in primary_separator
+        if comma_separated:
+            last_name, given_names_str = [s.strip() for s in full_name.strip().split(primary_separator, maxsplit=1)]
+        else:
+            given_names_str, last_name = [s.strip() for s in full_name.strip().rsplit(primary_separator, maxsplit=1)]
 
-        for sep in first_last_name_separators:
-            split_fullname = [name.strip() for name in full_name.split(sep)]
+        # Perform split of given names string into a first name and middle names, if required, and return entity
+        given_names_separators = [
+            " ",
+        ]
+        separators_present_in_given_name_str = [sep for sep in given_names_separators if sep in given_names_str]
 
-            if len(split_fullname) >= 2:
-                # identify first/last name order
-                if use_smart_first_name_detector:
-                    first_i, last_i = DOIPDS4LabelUtil._smart_first_last_name_detector(
-                        split_fullname, default_order=first_last_name_order
-                    )
-                else:
-                    first_i, last_i = tuple(first_last_name_order)
+        if separators_present_in_given_name_str:
+            separator = separators_present_in_given_name_str[0]
+            uses_abbreviation = separator == ". "
 
-                # re-add . if it has been removed as a separator
-                # it's unclear why this is being appended - this should be clarified
-                first_name_suffix = "." if sep == "." else ""
-
-                entity = {
-                    "first_name": split_fullname[first_i] + first_name_suffix,
-                    "last_name": split_fullname[last_i],
-                    "affiliation": [],
-                    "name_type": "Personal",
-                }
-
-                if len(split_fullname) >= 3:
-                    entity["middle_name"] = split_fullname[1]
-
-                break
-
-        # In practice, this default should never be reached, as it requires a mononym WITH a separator, like "somename,"
-        if not entity:
-            entity = {"name": full_name, "affiliation": [], "name_type": "Personal"}
-
-        logger.debug(f"parsed person {entity}")
-
-        return entity
+            first_name, middle_names_str = [s.strip() for s in given_names_str.split(separator, maxsplit=1)]
+            return {
+                "first_name": first_name + ("." if uses_abbreviation else ""),
+                "middle_name": middle_names_str,
+                "last_name": last_name,
+                "affiliation": [],
+                "name_type": "Personal",
+            }
+        else:
+            first_name_uses_abbreviation = primary_separator == ". "
+            return {
+                "first_name": given_names_str + ("." if first_name_uses_abbreviation else ""),
+                "last_name": last_name,
+                "affiliation": [],
+                "name_type": "Personal",
+            }
 
     def get_names(
         self,
         name_list: List[str],
-        first_last_name_order: Tuple[int, int] = (0, -1),
-        first_last_name_separators: Tuple[str] = (",", "."),
-    ) -> List[Dict[str, Union[str, List[str]]]]:
+    ) -> List[Dict[str, Union[str, Sequence[str]]]]:
         """
         Given a list of personal/organizational name strings and some parsing configuration, return a list of Dicts
         representing the named entities.
         :param name_list: a list of raw name strings to parse
-        :param first_last_name_order: a tuple of indices by which to identify the first and last name chunks, respectively
-        :param first_last_name_separators: a tuple of chars by which to split the full_name into a first and last name chunk
         :returns: a List of parsed entities
         :rtype: List[Dict[str, Union[str, List[str]]]]
         """
         logger.debug(f"name_list {name_list}")
-        logger.debug(f"first_last_name_order {first_last_name_order}")
 
         persons = []
 
         for full_name in name_list:
-            persons.append(self._get_name_components(full_name, first_last_name_order, first_last_name_separators))
+            persons.append(self._get_name_components(full_name))
 
         return persons
 
-    def get_author_names(self, name_list: List[str]) -> List[Dict[str, Union[str, List[str]]]]:
-        return self.get_names(name_list, first_last_name_order=(-1, 0))
+    def get_author_names(self, name_list: List[str]) -> List[Dict[str, Union[str, Sequence[str]]]]:
+        return self.get_names(name_list)
 
     def get_editor_names(self, name_list):
-        return self.get_names(name_list, first_last_name_separators=(",",))
+        return self.get_names(name_list)

--- a/src/pds_doi_service/core/input/test/data/pds4_bundle_with_utf-8-bom.xml
+++ b/src/pds_doi_service/core/input/test/data/pds4_bundle_with_utf-8-bom.xml
@@ -8,7 +8,7 @@
 <information_model_version>1.11.1.0</information_model_version>
 <product_class>Product_Bundle</product_class>
 <Citation_Information>
-<author_list>R. Deen, H. Abarca, P. Zamani, J.Maki</author_list>
+<author_list>R. Deen, H. Abarca, P. Zamani, J. Maki</author_list>
 
 
 <!-- <editor_list>Williams, D.R.; McLaughlin, S.A.</editor_list> -->

--- a/src/pds_doi_service/core/input/test/pds4_util_test.py
+++ b/src/pds_doi_service/core/input/test/pds4_util_test.py
@@ -83,5 +83,59 @@ class Pds4UtilTestCase(unittest.TestCase):
         self.assertSetEqual(doi.keywords, self.expected_keywords)
 
 
+class GetNamesTestCase(unittest.TestCase):
+    def test_names_parse_correctly(self):
+        entity_names = [
+            "A. Dunn",
+            "Dunn, Alex",
+            "Dunn, A.",
+            "Dunn, A. E.",
+            "Dunn, A. E. F. G.",
+            "Dunn, Alexander E.",
+            "Dunn, Alexander E. F. G.",
+            "Jet Propulsion Laboratory",
+            "JPL",
+            "Google Inc.",
+            "Suffixed Jr., James",
+        ]
+        parsed_entities = DOIPDS4LabelUtil().get_names(entity_names)
+        expected_parsed_entities = [
+            {"first_name": "A.", "last_name": "Dunn", "affiliation": [], "name_type": "Personal"},
+            {"first_name": "Alex", "last_name": "Dunn", "affiliation": [], "name_type": "Personal"},
+            {"first_name": "A.", "last_name": "Dunn", "affiliation": [], "name_type": "Personal"},
+            {"first_name": "A.", "middle_name": "E.", "last_name": "Dunn", "affiliation": [], "name_type": "Personal"},
+            {
+                "first_name": "A.",
+                "middle_name": "E. F. G.",
+                "last_name": "Dunn",
+                "affiliation": [],
+                "name_type": "Personal",
+            },
+            {
+                "first_name": "Alexander",
+                "middle_name": "E.",
+                "last_name": "Dunn",
+                "affiliation": [],
+                "name_type": "Personal",
+            },
+            {
+                "first_name": "Alexander",
+                "middle_name": "E. F. G.",
+                "last_name": "Dunn",
+                "affiliation": [],
+                "name_type": "Personal",
+            },
+            {
+                "name": "Jet Propulsion Laboratory",
+                "affiliation": ["Jet Propulsion Laboratory"],
+                "name_type": "Organizational",
+            },
+            {"name": "JPL", "affiliation": ["JPL"], "name_type": "Organizational"},
+            {"name": "Google Inc.", "affiliation": ["Google Inc."], "name_type": "Organizational"},
+            {"first_name": "James", "last_name": "Suffixed Jr.", "affiliation": [], "name_type": "Personal"},
+        ]
+        self.assertListEqual(expected_parsed_entities, parsed_entities)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/pds_doi_service/core/input/test/pds4_util_test.py
+++ b/src/pds_doi_service/core/input/test/pds4_util_test.py
@@ -24,9 +24,9 @@ class Pds4UtilTestCase(unittest.TestCase):
             {"first_name": "J.", "last_name": "Maki", "affiliation": [], "name_type": "Personal"},
         ]
         self.expected_editors = [
-            {"first_name": "P. H.", "last_name": "Smith", "affiliation": [], "name_type": "Personal"},
+            {"first_name": "P.", "middle_name": "H.", "last_name": "Smith", "affiliation": [], "name_type": "Personal"},
             {"first_name": "M.", "last_name": "Lemmon", "affiliation": [], "name_type": "Personal"},
-            {"first_name": "R. F.", "last_name": "Beebe", "affiliation": [], "name_type": "Personal"},
+            {"first_name": "R.", "middle_name": "F.", "last_name": "Beebe", "affiliation": [], "name_type": "Personal"},
         ]
         self.expected_keywords = {
             "mars",

--- a/tests/end_to_end/bundle_pds4.xml
+++ b/tests/end_to_end/bundle_pds4.xml
@@ -9,7 +9,7 @@
 <information_model_version>1.11.1.0</information_model_version>
 <product_class>Product_Bundle</product_class>
 <Citation_Information>
-<author_list>R. Deen, H. Abarca, P. Zamani, J.Maki</author_list>
+<author_list>R. Deen, H. Abarca, P. Zamani, J. Maki</author_list>
 
 
 <!-- <editor_list>Williams, D.R.; McLaughlin, S.A.</editor_list> -->


### PR DESCRIPTION
## 🗒️ Summary
Overhauls DOIPDS4LabelUtil.get_names() and its supporting private methods.

New implementation is more rigid, but more comprehensible and well-defined.  If we want more flexibility we need to implement personal/organizational entities (like are used for authors and editors) properly as classes, rather than just `Dict`s.  I understand this conversation is ongoing between @jordanpadams and other stakeholders as of last week.

Adds support for parsing of organizational names (ie those without separators).

Formats like `F.Lastname` are no longer supported.  Supported formats (per new unit tests) are

```
[
    "A. Dunn",
    "Dunn, Alex",
    "Dunn, A.",
    "Dunn, A. E.",
    "Dunn, A. E. F. G.",
    "Dunn, Alexander E.",
    "Dunn, Alexander E. F. G.",
    "Jet Propulsion Laboratory",
    "JPL",
    "Google Inc.",
    "Suffixed Jr., James",
]
```

## ⚙️ Test Data and/or Report
Unit tests pass

## ♻️ Related Issues
fixes #377 


