### PR TITLE
282 ads metadata

### DIFF
--- a/src/pds_doi_service/core/actions/test/reserve_test.py
+++ b/src/pds_doi_service/core/actions/test/reserve_test.py
@@ -204,7 +204,7 @@ class ReserveActionTestCase(unittest.TestCase):
 
         self.assertEqual(len(doi.authors), 4)
         self.assertEqual(len(doi.editors), 3)
-        self.assertEqual(len(doi.keywords), 17)
+        self.assertEqual(len(doi.keywords), 10)
         self.assertEqual(doi.pds_identifier, "urn:nasa:pds:insight_cameras::1.0")
         self.assertEqual(doi.product_type, ProductType.Collection)
         self.assertTrue(all(keyword in doi.keywords for keyword in get_global_keywords()))
@@ -234,7 +234,7 @@ class ReserveActionTestCase(unittest.TestCase):
 
         for doi in dois:
             self.assertEqual(len(doi.authors), 4)
-            self.assertEqual(len(doi.keywords), 17)
+            self.assertEqual(len(doi.keywords), 10)
             self.assertEqual(doi.product_type, ProductType.Collection)
             self.assertIsInstance(doi.publication_date, datetime)
             self.assertIsInstance(doi.date_record_added, datetime)
@@ -274,7 +274,7 @@ class ReserveActionTestCase(unittest.TestCase):
         doi = dois[0]
 
         self.assertEqual(len(doi.authors), 4)
-        self.assertEqual(len(doi.keywords), 17)
+        self.assertEqual(len(doi.keywords), 10)
         self.assertTrue(all(keyword in doi.keywords for keyword in get_global_keywords()))
         self.assertEqual(doi.pds_identifier, "urn:nasa:pds:insight_cameras::1.0")
         self.assertEqual(doi.product_type, ProductType.Collection)
@@ -305,7 +305,7 @@ class ReserveActionTestCase(unittest.TestCase):
         doi = dois[0]
 
         self.assertEqual(len(doi.authors), 4)
-        self.assertEqual(len(doi.keywords), 11)
+        self.assertEqual(len(doi.keywords), 8)
         self.assertEqual(doi.pds_identifier, "urn:nasa:pds:insight_cameras:data::1.0")
         self.assertEqual(doi.product_type, ProductType.Collection)
         self.assertTrue(all(keyword in doi.keywords for keyword in get_global_keywords()))
@@ -336,7 +336,7 @@ class ReserveActionTestCase(unittest.TestCase):
         doi = dois[0]
 
         self.assertEqual(len(doi.authors), 4)
-        self.assertEqual(len(doi.keywords), 11)
+        self.assertEqual(len(doi.keywords), 8)
         self.assertEqual(doi.pds_identifier, "urn:nasa:pds:insight_cameras:browse::1.0")
         self.assertEqual(doi.description, "Collection of BROWSE products.")
         self.assertEqual(doi.product_type, ProductType.Collection)
@@ -368,7 +368,7 @@ class ReserveActionTestCase(unittest.TestCase):
         doi = dois[0]
 
         self.assertEqual(len(doi.authors), 4)
-        self.assertEqual(len(doi.keywords), 13)
+        self.assertEqual(len(doi.keywords), 8)
         self.assertEqual(doi.pds_identifier, "urn:nasa:pds:insight_cameras:calibration::1.0")
         self.assertEqual(doi.description, "Collection of CALIBRATION files/products to include in the archive.")
         self.assertEqual(doi.product_type, ProductType.Collection)
@@ -400,7 +400,7 @@ class ReserveActionTestCase(unittest.TestCase):
         doi = dois[0]
 
         self.assertEqual(len(doi.authors), 4)
-        self.assertEqual(len(doi.keywords), 11)
+        self.assertEqual(len(doi.keywords), 8)
         self.assertEqual(doi.pds_identifier, "urn:nasa:pds:insight_cameras:document::1.0")
         self.assertEqual(doi.description, "Collection of DOCUMENT products.")
         self.assertEqual(doi.product_type, ProductType.Collection)

--- a/src/pds_doi_service/core/input/pds4_util.py
+++ b/src/pds_doi_service/core/input/pds4_util.py
@@ -322,7 +322,6 @@ class DOIPDS4LabelUtil:
             "observing_system_component",
             "target_identification",
             "primary_result_summary",
-            "description",
         }
 
         keyword_tokenizer = KeywordTokenizer()

--- a/src/pds_doi_service/core/input/test/pds4_util_test.py
+++ b/src/pds_doi_service/core/input/test/pds4_util_test.py
@@ -33,17 +33,10 @@ class Pds4UtilTestCase(unittest.TestCase):
             "insight",
             "lander",
             "camera",
-            "product",
             "context",
-            "reduced",
-            "experiment",
-            "edr",
-            "data",
             "raw",
             "science",
-            "rdr",
             "deployment",
-            "record",
         }
 
     def test_parse_dois_from_pds4_label(self):


### PR DESCRIPTION
## 🗒️ Summary
Removes "description" label elements from keyword extraction process

## ⚙️ Test Data and/or Report
Unit tests pass

## ♻️ Related Issues
fixes #282 