### PR TITLE
Pulls latest images during build phase in Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,6 +75,7 @@ pipeline {
                     sh 'echo "OSTI_USER=$u" >> doi_service.env'
                     sh 'echo "OSTI_PASSWORD=$p" >> doi_service.env'
                 }
+                sh "$compose pull --quiet"
             }
         }
         stage('🩺 Test') {


### PR DESCRIPTION
## 🗒️ Summary

This updates the Jenkins pipeline by forcibly pulling the latest images mentioned in the Docker Composition during the "build" phase.

## ⚙️ Test Data and/or Report

Before the fix:
```console
$ hostname
pds-expo.jpl.nasa.gov
$ docker image ls | egrep doi-service
nasapds/pds-doi-service                         latest              05492df9eb77   9 months ago    332MB
```
After the fix:
```console
$ docker image ls | egrep doi-service
nasapds/pds-doi-service                         latest              05492df9eb77   9 months ago    332MB
```
"But wait!" you exclaim. "This isn't fixed!" Ah, but the `nasapds/pds-doi-service:latest` image truly hasn't been updated in 9 months. [See for yourself](https://hub.docker.com/layers/nasapds/pds-doi-service/latest/images/sha256-b7a7b84f81fe96f89b29393dc4e9c8c8a563fc1b0f7ed49fd4c50f85281af2a4?context=explore).

Proof of the correctness of this fix is left as an exercise to the reviewers 😇


## ♻️ Related Issues

- [devops#34](https://github.com/NASA-PDS/devops/issues/34)
