### PR TITLE
Bring Roundup time to 45 minutes and enable it to complete to green

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Python build, virtual environments, and buildouts
+.venv
 venv
 __pycache__/
 dist/

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,12 +38,12 @@ install_requires =
     itsdangerous==2.0.1
     jinja2==3.0.1
     jsonschema==3.0.0
-    lxml>=4.5
+    lxml==4.6.3
     nltk==3.5
-    numpy>=1.18
+    numpy==1.21.2
     openapi-schema-validator==0.1.4
     openpyxl~=3.0.7
-    pandas~=1.4.4
+    pandas==1.3.4
     python-dateutil>=2.8
     python-jose[cryptography]
     pytz==2020.1
@@ -86,7 +86,7 @@ dev =
     pre-commit
     sphinx
     sphinxcontrib-napoleon
-    tox
+    tox==3.28.0
     flask_testing==0.8.0
     sphinx-rtd-theme==0.5.0
     sphinx-argparse==0.2.5
@@ -103,6 +103,7 @@ dev =
     types-requests
     types-six
     types-waitress
+    virtualenv==20.8.1
 
 # 👉 Note: The ``-stubs`` and ``types-`` dependencies above ↑ in the ``dev``
 # extra must be duplicated in ``.pre-commit-config.yaml`` in order for ``tox``

--- a/src/pds_doi_service/api/util.py
+++ b/src/pds_doi_service/api/util.py
@@ -14,7 +14,7 @@ This module is adapted from the SwaggerHub auto-generated util.py.
 """
 import datetime
 import typing
-from collections import Iterable
+from typing import Iterable
 
 import six
 

--- a/src/pds_doi_service/core/actions/update.py
+++ b/src/pds_doi_service/core/actions/update.py
@@ -247,7 +247,6 @@ class DOICoreActionUpdate(DOICoreAction):
         return updated_dois
 
     def _get_doi_record_from_pds_identifier(self, pds_identifier):
-
         # Get the record from the transaction database for the current DOI value
         transaction_record = self._list_action.transaction_for_identifier(pds_identifier)
 
@@ -265,7 +264,6 @@ class DOICoreActionUpdate(DOICoreAction):
         return existing_dois[0]
 
     def _get_doi_record_from_doi_identifier(self, doi_identifier):
-
         # Get the record from the transaction database for the current DOI value
         transaction_record = self._list_action.transaction_for_doi(doi_identifier)
 

--- a/src/pds_doi_service/core/input/input_util.py
+++ b/src/pds_doi_service/core/input/input_util.py
@@ -40,7 +40,6 @@ logger = get_logger(__name__)
 
 
 class DOIInputUtil:
-
     MANDATORY_COLUMNS = [
         "title",
         "publication_date",

--- a/src/pds_doi_service/core/outputs/test/doi_validator_test.py
+++ b/src/pds_doi_service/core/outputs/test/doi_validator_test.py
@@ -401,8 +401,9 @@ class DoiValidatorTest(unittest.TestCase):
             self._doi_validator._check_identifier_fields(doi_obj)
 
     def test_site_url_validation(self):
-        """ """
-        # Test with an unreachable (fake) URL
+        """
+        Test validation of site URLs with an unreachable (fake) URL.
+        """
         doi_obj = Doi(
             title=self.title + " different",
             publication_date=self.transaction_date,

--- a/src/pds_doi_service/core/util/config_parser.py
+++ b/src/pds_doi_service/core/util/config_parser.py
@@ -83,7 +83,7 @@ class DOIConfigUtil:
     def _resolve_relative_path(parser):
         # resolve relative path with sys.prefix base path
         for section in parser.sections():
-            for (key, val) in parser.items(section):
+            for key, val in parser.items(section):
                 if key.endswith("_file") or key.endswith("_dir"):
                     parser[section][key] = os.path.abspath(os.path.join(sys.prefix, val))
 

--- a/src/pds_doi_service/core/util/test/contributors_util_test.py
+++ b/src/pds_doi_service/core/util/test/contributors_util_test.py
@@ -10,7 +10,6 @@ class ContributorsUtilTestCase(unittest.TestCase):
     )
 
     def test_authorized_contributor(self):
-
         authorized_contributor = (
             "Cartography and Imaging Sciences Discipline" in self._doi_contributor_util.get_permissible_values()
         )


### PR DESCRIPTION
## 🗒️ Summary

Merge this to have the DOI service complete its Roundup. In the sandbox and with the free version of GitHub Actions, this was 45 minutes. This doesn't satisfy the acceptance criterion of 30 minutes as stipulated in #403 but we're going to give this one a pass.

## ⚙️ Test Data and/or Report

See [this run in the sandbox](https://github.com/nasa-pds-engineering-node/doi-service/actions/runs/4755380635).

## ♻️ Related Issues

- #403 
