### PR TITLE
Make this pip-installable with the dev extra again (bonus: no more Dependency Confusion Vulnerabilities)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 
 [options]
 install_requires =
-    appdirs>=1.4
+    appdirs~=1.4.4
     bs4==0.0.1
     certifi==2020.4.5.1
     chardet==3.0.4
@@ -44,20 +44,20 @@ install_requires =
     openapi-schema-validator==0.1.4
     openpyxl~=3.0.7
     pandas==1.3.4
-    python-dateutil>=2.8
+    python-dateutil~=2.9.0.post0
     python-jose[cryptography]
     pytz==2020.1
-    requests>=2.23
-    six>=1.14
-    soupsieve>=2.0
-    urllib3>=1.25
+    requests~=2.32.3
+    six~=1.16.0
+    soupsieve~=2.6
+    urllib3~=2.2.3
     waitress==2.0.0
     Werkzeug==0.16.0
     wheel
     xlrd>=1.2
     xmlschema==1.5.1
-    xmltodict>=0.12
-    zipp>=3.1
+    xmltodict~=0.13.0
+    zipp~=3.20.2
 zip_safe = False
 include_package_data = True
 package_dir =
@@ -69,41 +69,39 @@ test_suite = pds_doi_service.test.suite
 
 [options.extras_require]
 dev =
-    build
-    black
-    wheel
-    flake8
-    flake8-bugbear
-    flake8-docstrings
-    pep8-naming
-    mypy
-    pydocstyle
-    coverage
-    pytest
-    pytest-cov
-    pytest-watch
-    pytest-xdist
-    pre-commit
+    build~=1.2.2
+    black~=24.8.0
+    flake8~=7.1.1
+    flake8-bugbear~=24.8.19
+    flake8-docstrings~=1.7.0
+    pep8-naming~=0.14.1
+    mypy~=1.11.2
+    pydocstyle~=6.3.0
+    coverage~=7.6.1
+    pytest~=8.3.3
+    pytest-cov~=5.0.0
+    pytest-watch~=4.2.0
+    pytest-xdist~=3.6.1
+    pre-commit~=2.20.0
     sphinx==3.2.1
-    sphinxcontrib-napoleon
-    tox==3.28.0
-    flask_testing==0.8.0
-    sphinx-rtd-theme==0.5.0
-    sphinx-argparse==0.2.5
-    behave==1.2.6
-    allure-behave==2.8.13
-    behave-testrail-reporter==0.4.0
+    sphinxcontrib-napoleon~=0.7
+    tox~=3.28.0
+    flask_testing~=0.8.0
+    sphinx-rtd-theme~=0.5.0
+    sphinx-argparse~=0.2.5
+    behave~=1.2.6
+    allure-behave~=2.8.13
+    behave-testrail-reporter~=0.4.0
     pygit2~=1.9.2
-    lxml-stubs
-    pandas-stubs
-    types-flask
-    types-jsonschema
-    types-pkg_resources
-    types-python-dateutil
-    types-requests
-    types-six
-    types-waitress
-    virtualenv==20.8.1
+    lxml-stubs~=0.5.1
+    pandas-stubs~=2.0.1.230501
+    types-flask~=1.1.6
+    types-jsonschema~=4.23.0.20240813
+    types-python-dateutil~=2.9.0.20240906
+    types-requests~=2.32.0.20240914
+    types-six~=1.16.21.20240513
+    types-waitress~=3.0.0.20240423
+    virtualenv~=20.8.1
 
 # 👉 Note: The ``-stubs`` and ``types-`` dependencies above ↑ in the ``dev``
 # extra must be duplicated in ``.pre-commit-config.yaml`` in order for ``tox``


### PR DESCRIPTION
## 🗒️ Summary

While looking at some Dependabot issues, I noticed that this package could not be installed with `pip install --editable '.[dev]'`. I also noticed a large number of [Dependency Confusion Vulnerabilities](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610).

Merge this to make it installable again with the `[dev]` extra and to close those vulnerabilities.

## ⚙️ Test Data and/or Report

BEFORE:
```
INFO: pip is looking at multiple versions of pds-doi-service[dev] to determine which version is compatible with other requirements. This could take a while.
ERROR: Ignored the following yanked versions: 0.1.0, 0.1.1, 0.1.2, 0.1.3
ERROR: Ignored the following versions that require a different python version: 0.5.0 Requires-Python >=3.10; 0.5.1 Requires-Python >=3.10; 0.5.2 Requires-Python >=3.10; 2.1.0 Requires-Python >=3.10; 2.1.0rc1 Requires-Python >=3.10; 2.1.1 Requires-Python >=3.10; 2.2.2.240909 Requires-Python >=3.10; 8.0.0 Requires-Python >=3.10; 8.0.0rc1 Requires-Python >=3.10; 8.0.1 Requires-Python >=3.10; 8.0.2 Requires-Python >=3.10
ERROR: Could not find a version that satisfies the requirement types-pkg-resources; extra == "dev" (from pds-doi-service[dev]) (from versions: none)
ERROR: No matching distribution found for types-pkg-resources; extra == "dev"
```

AFTER:
```
Successfully installed pds-doi-service-2.5.0
```

NOTE: The tests still fail. But at least it installs now.

## ♻️ Related Issues

N/A.
