### PR TITLE
Fix code scanning alert no. 59: Overly permissive file permissions

### DIFF
--- a/src/pds_doi_service/core/db/transaction_on_disk.py
+++ b/src/pds_doi_service/core/db/transaction_on_disk.py
@@ -170,7 +170,7 @@ class TransactionOnDisk:
                     r.close()
 
                 # Set up permissions for copied input
-                os.chmod(full_input_name, 0o0664)
+                os.chmod(full_input_name, 0o0600)
 
         # Write output file with provided content
         # The extension of the file is determined by the provided content type
@@ -181,7 +181,7 @@ class TransactionOnDisk:
                 outfile.write(output_content)
 
             # Set up permissions for copied output
-            os.chmod(full_output_name, 0o0664)
+            os.chmod(full_output_name, 0o0600)
 
         logger.info(f"Transaction files saved to {transaction_dir}")
 


### PR DESCRIPTION
Fixes [https://github.com/NASA-PDS/doi-service/security/code-scanning/59](https://github.com/NASA-PDS/doi-service/security/code-scanning/59)

To fix the problem, we need to change the file permissions to be more restrictive, allowing only the owner to read and write the file. This can be achieved by modifying the `os.chmod` calls to set the file permissions to `0o0600`, which grants read and write permissions only to the file owner.

Specifically, we need to update the `os.chmod` calls on lines 173 and 184 to use `0o0600` instead of `0o0664`. This change ensures that the files are not world-readable and are only accessible by the owner.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
