### PR TITLE
Fix code scanning alert no. 58: Overly permissive file permissions

### DIFF
--- a/src/pds_doi_service/core/db/transaction_on_disk.py
+++ b/src/pds_doi_service/core/db/transaction_on_disk.py
@@ -170,7 +170,7 @@ class TransactionOnDisk:
                     r.close()
 
                 # Set up permissions for copied input
-                os.chmod(full_input_name, 0o0664)
+                os.chmod(full_input_name, 0o0600)
 
         # Write output file with provided content
         # The extension of the file is determined by the provided content type
@@ -181,7 +181,7 @@ class TransactionOnDisk:
                 outfile.write(output_content)
 
             # Set up permissions for copied output
-            os.chmod(full_output_name, 0o0664)
+            os.chmod(full_output_name, 0o0600)
 
         logger.info(f"Transaction files saved to {transaction_dir}")
 


### PR DESCRIPTION
Fixes [https://github.com/NASA-PDS/doi-service/security/code-scanning/58](https://github.com/NASA-PDS/doi-service/security/code-scanning/58)

To fix the problem, we need to change the file permissions to be more restrictive. Specifically, we should set the permissions so that only the owner can read and write the file, and no one else can access it. This can be achieved by changing the mode in the `os.chmod` function from `0o0664` to `0o0600`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
