### PR TITLE
Upgrade to Python 3.13

### DIFF
--- a/.github/workflows/branch-cicd.yaml
+++ b/.github/workflows/branch-cicd.yaml
@@ -43,7 +43,7 @@ jobs:
                 name: Set up Python 3
                 uses: actions/setup-python@v5
                 with:
-                    python-version: '3.9'
+                    python-version: '3.13'
             -
                 name: 💵 Python Cache
                 uses: actions/cache@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,10 +40,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Setup python 3.9
+    - name: Setup python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.13
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/secrets-detection.yaml
+++ b/.github/workflows/secrets-detection.yaml
@@ -47,7 +47,7 @@ jobs:
                     detect-secrets scan --disable-plugin AbsolutePathDetectorExperimental --baseline .secrets.new \
                         --exclude-files '\.secrets..*' \
                         --exclude-files '\.git.*' \
-                        --exclude-files '\.pre-commit-config.yaml' \
+                        --exclude-files '\.pre-commit-config\.yaml' \
                         --exclude-files '\.mypy_cache' \
                         --exclude-files '\.pytest_cache' \
                         --exclude-files '\.tox' \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,14 +18,17 @@ repos:
     -   id: reorder-python-imports
         files: ^src/|tests/
 
--   repo: local
-    hooks:
-    -   id: black
-        name: black
-        entry: black
-        files: ^src/|tests/
-        language: system
-        types: [python]
+# Disabling "black" for now as it's conflicting with reorder_python_imports
+# (They keep fighting over whether to have a blank line before imports)
+#
+# -   repo: local
+#     hooks:
+#     -   id: black
+#         name: black
+#         entry: black
+#         files: ^src/|tests/
+#         language: system
+#         types: [python]
 
 -   repo: local
     hooks:
@@ -50,10 +53,13 @@ repos:
     hooks:
       - id: detect-secrets
         args:
+          - '--disable-plugin'
+          - 'AbsolutePathDetectorExperimental'
           - '--baseline'
           - '.secrets.baseline'
           - --exclude-files '\.secrets..*'
           - --exclude-files '\.git.*'
+          - --exclude-files '\.pre-commit-config\.yaml'
           - --exclude-files '\.mypy_cache'
           - --exclude-files '\.pytest_cache'
           - --exclude-files '\.tox'

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Planetary Data System (PDS) Digital Object Identifier (DOI) Service provides
 
 ## Prerequisites
 
-- Python 3.9 or above
+- Python 3.13 or above
 - A login to the DOI Service Provider endpoint server (currently DataCite)
 
 
@@ -38,7 +38,7 @@ If you get an error like
 
     src/types.h:36:2: error: You need a compatible libgit2 version (1.1.x)
 
-then you're probably using [brew.sh](https://brew.sh)'s Python 3.10. Use their Python 3.9 instead.
+then you're probably using [brew.sh](https://brew.sh)'s Python 3.10. Use their Python 3.13 instead.
 
 Update your local configuration to access the DOI service provider's test server.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,12 +34,8 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
-    "sphinx_rtd_theme",
     "sphinxarg.ext",
 ]
-
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -63,8 +59,6 @@ html_static_path = ["_static"]
 
 html_theme_options = {
     "canonical_url": "",
-    "logo_only": False,
-    "display_version": True,
     "prev_next_buttons_location": "bottom",
     "style_external_links": False,
     # Toc options
@@ -77,8 +71,6 @@ html_theme_options = {
 
 html_logo = "_static/images/PDS_Planets.png"
 
-html_context = {
-    "css_files": [
-        "_static/theme_overrides.css",  # override wide tables in RTD theme
-    ],
-}
+html_css_files = [
+    'theme_overrides.css',
+]

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -9,7 +9,7 @@ Requirements
 Prior to installing this software, ensure your system meets the following
 requirements:
 
-•  Python_ 3.9 or above. Python 2 will absolutely *not* work.
+•  Python_ 3.13 or above. Python 2 will absolutely *not* work.
 •  ``libxml2`` version 2.9.2; later 2.9 versions are fine.  Run ``xml2-config
    --version`` to find out.
 •  ``libxslt`` version 1.1.28; later 1.1 versions are OK too. Run ``xslt-config`` to see.

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     Environment :: Web Environment
     Framework :: Flask
     Intended Audience :: Science/Research
-    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Topic :: Scientific/Engineering
@@ -39,12 +38,12 @@ install_requires =
     itsdangerous==2.0.1
     jinja2==3.1.4
     jsonschema~=3.0.0
-    lxml==5.3.0
+    lxml==6.0.0
     nltk==3.5
-    numpy==1.21.2
+    numpy==2.2.3
     openapi-schema-validator~=0.1.4
-    openpyxl~=3.0.7
-    pandas==1.3.4
+    openpyxl~=3.1.0
+    pandas==2.3.0
     python-dateutil~=2.9.0.post0
     python-jose[cryptography]
     pytz==2020.1
@@ -64,16 +63,16 @@ include_package_data = True
 package_dir =
     = src
 packages = find:
-python_requires = >= 3.9
+python_requires = >= 3.13
 test_suite = pds_doi_service.test.suite
 
 
 [options.extras_require]
 dev =
+    aiosmtpd~=1.4.6
     build~=1.2.2
-    black~=24.8.0
-    flake8~=7.1.1
-    flake8-bugbear~=24.8.19
+    flake8~=7.3.0
+    flake8-bugbear~=24.12.12
     flake8-docstrings~=1.7.0
     pep8-naming~=0.14.1
     pydocstyle~=6.3.0
@@ -83,18 +82,18 @@ dev =
     pytest-watch~=4.2.0
     pytest-xdist~=3.6.1
     pre-commit~=3.3.3
-    sphinx~=5.0.0
-    sphinx-rtd-theme~=0.5.0
+    sphinx~=8.2.3
+    sphinx-rtd-theme~=3.0.2
     types-setuptools~=68.1.0.0
     sphinxcontrib-napoleon~=0.7
     tox>=3.28,<4.24
     flask_testing~=0.8.0
-    sphinx-rtd-theme>=0.5,<3.1
+    sphinx-rtd-theme~=3.0.2
     sphinx-argparse~=0.2.5
     behave~=1.2.6
     allure-behave~=2.8.13
     behave-testrail-reporter~=0.4.0
-    pygit2~=1.9.2
+    pygit2~=1.18.2
     lxml-stubs~=0.5.1
     pandas-stubs~=2.0.1.230501
     types-flask~=1.1.6

--- a/src/pds_doi_service/__init__.py
+++ b/src/pds_doi_service/__init__.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
 """Planetary Data System's Digital Object Identifier service"""
-import pkg_resources
+import importlib.resources
 
-__version__ = VERSION = pkg_resources.resource_string(__name__, "VERSION.txt").decode("utf-8").strip()
+__version__ = VERSION = importlib.resources.files(__name__).joinpath("VERSION.txt").read_text().strip()

--- a/src/pds_doi_service/api/test/test_dois_controller.py
+++ b/src/pds_doi_service/api/test/test_dois_controller.py
@@ -5,6 +5,7 @@ import json
 import os
 import unittest
 from datetime import datetime
+from importlib import resources
 from os.path import abspath
 from os.path import exists
 from os.path import join
@@ -24,7 +25,6 @@ from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_XML
 from pds_doi_service.core.outputs.service import DOIServiceFactory
 from pds_doi_service.core.outputs.service import SERVICE_TYPE_DATACITE
 from pds_doi_service.core.util.config_parser import DOIConfigUtil
-from pkg_resources import resource_filename
 
 from ._base import BaseTestCase
 
@@ -47,7 +47,7 @@ class TestDoisController(BaseTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__))
         cls.test_data_dir = join(cls.test_dir, "data")
         cls.input_dir = abspath(join(cls.test_dir, os.pardir, os.pardir, os.pardir, os.pardir, "input"))
         cls.service_type = DOIServiceFactory.get_service_type()

--- a/src/pds_doi_service/core/actions/action.py
+++ b/src/pds_doi_service/core/actions/action.py
@@ -111,7 +111,7 @@ class DOICoreAction:
             if kwarg in kwargs:
                 setattr(self, f"_{kwarg}", kwargs[kwarg])
 
-            logger.debug(f"{kwarg} = {getattr(self,  f'_{kwarg}')}")
+            logger.debug(f"{kwarg} = {getattr(self, f'_{kwarg}')}")
 
     def run(self, **kwargs):
         """

--- a/src/pds_doi_service/core/actions/check.py
+++ b/src/pds_doi_service/core/actions/check.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from email.message import EmailMessage
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
+from importlib import resources
 from os.path import exists
 
 import jinja2
@@ -29,7 +30,6 @@ from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_JSON
 from pds_doi_service.core.outputs.service import DOIServiceFactory
 from pds_doi_service.core.util.emailer import Emailer
 from pds_doi_service.core.util.general_util import get_logger
-from pkg_resources import resource_filename
 
 logger = get_logger(__name__)
 
@@ -55,11 +55,11 @@ class DOICoreActionCheck(DOICoreAction):
         self._email = True
         self._attachment = True
 
-        self.email_header_template_file = resource_filename(
-            __name__, os.path.join("templates", "email_template_header.txt")
+        self.email_header_template_file = str(
+            resources.files(__name__) / "templates" / "email_template_header.txt"
         )
-        self.email_body_template_file = resource_filename(
-            __name__, os.path.join("templates", "email_template_body.txt")
+        self.email_body_template_file = str(
+            resources.files(__name__) / "templates" / "email_template_body.txt"
         )
 
         # Make sure templates are where we expect them to be

--- a/src/pds_doi_service/core/actions/roundup/email.py
+++ b/src/pds_doi_service/core/actions/roundup/email.py
@@ -17,6 +17,7 @@ import os
 from email import encoders
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from importlib import resources
 from typing import List
 
 import jinja2
@@ -26,11 +27,10 @@ from pds_doi_service.core.actions.roundup.output import prepare_doi_record_for_e
 from pds_doi_service.core.db.doi_database import DOIDataBase
 from pds_doi_service.core.entities.doi import DoiRecord
 from pds_doi_service.core.util.emailer import Emailer as PDSEmailer
-from pkg_resources import resource_filename
 
 
 def get_email_content_template(template_filename: str = "email_weekly_roundup.jinja2") -> jinja2.Template:
-    template_filepath = resource_filename(__name__, os.path.join("../templates", template_filename))
+    template_filepath = str(resources.files(__name__).parent / "templates" / template_filename)
     logging.info(f"Using template {template_filepath}")
     with open(template_filepath, "r") as infile:
         template = jinja2.Template(infile.read())

--- a/src/pds_doi_service/core/actions/roundup/test/base.py
+++ b/src/pds_doi_service/core/actions/roundup/test/base.py
@@ -4,17 +4,17 @@ import tempfile
 import unittest
 from datetime import datetime
 from datetime import timedelta
+from importlib import resources
 
 from pds_doi_service.core.actions.roundup.enumerate import get_start_of_local_week
 from pds_doi_service.core.db.doi_database import DOIDataBase
 from pds_doi_service.core.entities.doi import DoiRecord
 from pds_doi_service.core.entities.doi import DoiStatus
 from pds_doi_service.core.entities.doi import ProductType
-from pkg_resources import resource_filename
 
 
 class WeeklyRoundupNotificationBaseTestCase(unittest.TestCase):
-    tests_dir = os.path.abspath(resource_filename(__name__, ""))
+    tests_dir = str(resources.files(__name__))
     resources_dir = os.path.join(tests_dir, "resources")
 
     _database_obj: DOIDataBase

--- a/src/pds_doi_service/core/actions/test/check_test.py
+++ b/src/pds_doi_service/core/actions/test/check_test.py
@@ -8,6 +8,7 @@ import tempfile
 import time
 import unittest
 from email import message_from_bytes
+from importlib import resources
 from os.path import abspath
 from os.path import dirname
 from os.path import join
@@ -27,11 +28,10 @@ from pds_doi_service.core.outputs.service import DOIServiceFactory
 from pds_doi_service.core.outputs.service import SERVICE_TYPE_DATACITE
 from pds_doi_service.core.outputs.service import SERVICE_TYPE_OSTI
 from pds_doi_service.core.util.config_parser import DOIConfigUtil
-from pkg_resources import resource_filename
 
 
 class CheckActionTestCase(unittest.TestCase):
-    test_dir = resource_filename(__name__, "")
+    test_dir = str(resources.files(__name__))
     input_dir = abspath(join(test_dir, "data"))
 
     @classmethod

--- a/src/pds_doi_service/core/actions/test/list_test.py
+++ b/src/pds_doi_service/core/actions/test/list_test.py
@@ -3,6 +3,7 @@ import json
 import os
 import tempfile
 import unittest
+from importlib import resources
 from os.path import abspath
 from os.path import join
 from unittest.mock import patch
@@ -22,7 +23,6 @@ from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_JSON
 from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_XML
 from pds_doi_service.core.outputs.service import DOIServiceFactory
 from pds_doi_service.core.outputs.web_client import WEB_METHOD_POST
-from pkg_resources import resource_filename
 
 
 # TODO: add additional unit tests for other list query parameters
@@ -33,7 +33,7 @@ class ListActionTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__))
         cls.input_dir = abspath(join(cls.test_dir, "data"))
         cls.db_name = join(cls.test_dir, "doi_temp.db")
         cls._list_action = DOICoreActionList(db_name=cls.db_name)

--- a/src/pds_doi_service/core/actions/test/release_test.py
+++ b/src/pds_doi_service/core/actions/test/release_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import unittest
+from importlib import resources
 from os.path import abspath
 from os.path import join
 from unittest.mock import patch
@@ -15,7 +16,6 @@ from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_XML
 from pds_doi_service.core.outputs.service import DOIServiceFactory
 from pds_doi_service.core.outputs.web_client import WEB_METHOD_POST
 from pds_doi_service.core.util.general_util import get_global_keywords
-from pkg_resources import resource_filename
 
 
 class ReleaseActionTestCase(unittest.TestCase):
@@ -25,7 +25,7 @@ class ReleaseActionTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__))
         cls.input_dir = abspath(join(cls.test_dir, "data"))
 
         # Remove db_name if exist to have a fresh start otherwise exception will be

--- a/src/pds_doi_service/core/actions/test/reserve_test.py
+++ b/src/pds_doi_service/core/actions/test/reserve_test.py
@@ -2,6 +2,7 @@
 import os
 import unittest
 from datetime import datetime
+from importlib import resources
 from os.path import abspath
 from os.path import join
 from unittest.mock import patch
@@ -16,7 +17,6 @@ from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_XML
 from pds_doi_service.core.outputs.service import DOIServiceFactory
 from pds_doi_service.core.outputs.web_client import WEB_METHOD_POST
 from pds_doi_service.core.util.general_util import get_global_keywords
-from pkg_resources import resource_filename
 
 
 class ReserveActionTestCase(unittest.TestCase):
@@ -26,7 +26,7 @@ class ReserveActionTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__))
         cls.input_dir = abspath(join(cls.test_dir, "data"))
 
         # Remove db_name if exist to have a fresh start otherwise exception will be

--- a/src/pds_doi_service/core/actions/test/update_test.py
+++ b/src/pds_doi_service/core/actions/test/update_test.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import unittest
 from datetime import datetime
+from importlib import resources
 from os.path import abspath
 from os.path import join
 from unittest.mock import patch
@@ -22,7 +23,6 @@ from pds_doi_service.core.outputs.service import DOIServiceFactory
 from pds_doi_service.core.outputs.web_client import WEB_METHOD_POST
 from pds_doi_service.core.util.general_util import create_landing_page_url
 from pds_doi_service.core.util.general_util import get_global_keywords
-from pkg_resources import resource_filename
 
 
 class UpdateActionTestCase(unittest.TestCase):
@@ -34,7 +34,7 @@ class UpdateActionTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__))
         cls.input_dir = abspath(join(cls.test_dir, "data"))
         cls.db_name = join(cls.test_dir, "doi_temp.db")
         cls._update_action = DOICoreActionUpdate(db_name=cls.db_name)

--- a/src/pds_doi_service/core/db/test/doi_database_test.py
+++ b/src/pds_doi_service/core/db/test/doi_database_test.py
@@ -3,6 +3,7 @@ import datetime
 import os
 import unittest
 from datetime import timezone
+from importlib import resources
 from os.path import exists
 
 from pds_doi_service.core.db.doi_database import DOIDataBase
@@ -10,7 +11,6 @@ from pds_doi_service.core.entities.doi import DoiRecord
 from pds_doi_service.core.entities.doi import DoiStatus
 from pds_doi_service.core.entities.doi import ProductType
 from pds_doi_service.core.util.general_util import get_logger
-from pkg_resources import resource_filename
 
 logger = get_logger(__name__)
 
@@ -19,7 +19,7 @@ class DOIDatabaseTest(unittest.TestCase):
     """Unit tests for the doi_database.py module"""
 
     def setUp(self):
-        self._db_name = resource_filename(__name__, "doi_temp.db")
+        self._db_name = str(resources.files(__name__) / "doi_temp.db")
 
         # Delete temporary db if it already exists, this can occur when tests
         # are terminated before completion (during debugging for example)

--- a/src/pds_doi_service/core/db/test/transaction_test.py
+++ b/src/pds_doi_service/core/db/test/transaction_test.py
@@ -5,6 +5,7 @@ import time
 import unittest
 from datetime import datetime
 from datetime import timezone
+from importlib import resources
 
 from pds_doi_service.core.db.doi_database import DOIDataBase
 from pds_doi_service.core.db.transaction import Transaction
@@ -14,7 +15,6 @@ from pds_doi_service.core.entities.doi import Doi
 from pds_doi_service.core.entities.doi import DoiStatus
 from pds_doi_service.core.entities.doi import ProductType
 from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_JSON
-from pkg_resources import resource_filename
 
 
 class TransactionTestCase(unittest.TestCase):
@@ -23,7 +23,7 @@ class TransactionTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__))
 
         if os.path.isfile(cls.db_name):
             os.remove(cls.db_name)
@@ -112,7 +112,7 @@ class TransactionBuilderTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__))
 
         if os.path.isfile(cls.db_name):
             os.remove(cls.db_name)
@@ -158,7 +158,7 @@ class TransactionOnDiskTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__))
         cls.data_dir = os.path.join(cls.test_dir, "data")
 
     def test_transaction_write_to_disk(self):

--- a/src/pds_doi_service/core/input/pds4_util.py
+++ b/src/pds_doi_service/core/input/pds4_util.py
@@ -142,9 +142,9 @@ class DOIPDS4LabelUtil:
 
         logger.debug(
             f"num_dots_found,num_person_names,len(names_list),names_list "
-            f"{num_dots_found,num_person_names,len(names_list),names_list}"
+            f"{num_dots_found, num_person_names, len(names_list), names_list}"
         )
-        logger.debug(f"o_list_contains_full_name_flag " f"{o_list_contains_full_name_flag,names_list,len(names_list)}")
+        logger.debug(f"o_list_contains_full_name_flag " f"{o_list_contains_full_name_flag, names_list, len(names_list)}")
 
         return o_list_contains_full_name_flag
 
@@ -208,13 +208,13 @@ class DOIPDS4LabelUtil:
 
         logger.debug(
             f"o_best_method,pds4_fields_authors "
-            f"{o_best_method,pds4_fields_authors} "
+            f"{o_best_method, pds4_fields_authors} "
             f"number_commas,number_semi_colons "
-            f"{number_commas,number_semi_colons}"
+            f"{number_commas, number_semi_colons}"
         )
         logger.debug(
             f"len(authors_from_comma_split),len(authors_from_semi_colon_split) "
-            f"{len(authors_from_comma_split),len(authors_from_semi_colon_split)}"
+            f"{len(authors_from_comma_split), len(authors_from_semi_colon_split)}"
         )
 
         return o_best_method
@@ -248,7 +248,7 @@ class DOIPDS4LabelUtil:
             elif o_best_method == BestParserMethod.BY_SEMI_COLON:
                 authors_list = pds4_fields["authors"].split(";")
             else:
-                logger.error(f"o_best_method,pds4_fields['authors'] " f"{o_best_method,pds4_fields['authors']}")
+                logger.error(f"o_best_method,pds4_fields['authors'] " f"{o_best_method, pds4_fields['authors']}")
                 raise InputFormatException("Cannot split the authors using comma or semi-colon.")
 
             doi_suffix = None

--- a/src/pds_doi_service/core/input/test/input_util_test.py
+++ b/src/pds_doi_service/core/input/test/input_util_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import datetime
 import unittest
+from importlib import resources
 from os.path import abspath
 from os.path import join
 
@@ -11,12 +12,11 @@ from pds_doi_service.core.entities.exceptions import InputFormatException
 from pds_doi_service.core.input.input_util import DOIInputUtil
 from pds_doi_service.core.outputs.service import DOIServiceFactory
 from pds_doi_service.core.outputs.service import SERVICE_TYPE_OSTI
-from pkg_resources import resource_filename
 
 
 class InputUtilTestCase(unittest.TestCase):
     def setUp(self):
-        self.test_dir = resource_filename(__name__, "")
+        self.test_dir = str(resources.files(__name__))
         self.input_dir = abspath(join(self.test_dir, "data"))
 
     def test_parse_dois_from_input_file(self):

--- a/src/pds_doi_service/core/input/test/pds4_util_test.py
+++ b/src/pds_doi_service/core/input/test/pds4_util_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import unittest
 from datetime import datetime
+from importlib import resources
 from os.path import abspath
 from os.path import join
 
@@ -9,12 +10,11 @@ from pds_doi_service.core.entities.doi import Doi
 from pds_doi_service.core.entities.doi import DoiStatus
 from pds_doi_service.core.entities.doi import ProductType
 from pds_doi_service.core.input.pds4_util import DOIPDS4LabelUtil
-from pkg_resources import resource_filename
 
 
 class Pds4UtilTestCase(unittest.TestCase):
     def setUp(self):
-        self.test_dir = resource_filename(__name__, "")
+        self.test_dir = str(resources.files(__name__))
         self.input_dir = abspath(join(self.test_dir, "data"))
 
         self.expected_authors = [

--- a/src/pds_doi_service/core/outputs/datacite/datacite_record.py
+++ b/src/pds_doi_service/core/outputs/datacite/datacite_record.py
@@ -13,6 +13,7 @@ Contains classes used to create DataCite-compatible labels from Doi objects in
 memory.
 """
 import json
+from importlib import resources
 from os.path import exists
 
 import jinja2
@@ -23,7 +24,6 @@ from pds_doi_service.core.outputs.doi_record import DOIRecord
 from pds_doi_service.core.util.config_parser import DOIConfigUtil
 from pds_doi_service.core.util.general_util import get_logger
 from pds_doi_service.core.util.general_util import sanitize_json_string
-from pkg_resources import resource_filename
 
 logger = get_logger(__name__)
 
@@ -41,7 +41,7 @@ class DOIDataCiteRecord(DOIRecord):
         self._config = DOIConfigUtil().get_config()
 
         # Locate the jinja template
-        self._json_template_path = resource_filename(__name__, "DOI_DataCite_template_20210520-jinja2.json")
+        self._json_template_path = str(resources.files(__name__) / "DOI_DataCite_template_20210520-jinja2.json")
 
         if not exists(self._json_template_path):
             raise RuntimeError(

--- a/src/pds_doi_service/core/outputs/datacite/datacite_validator.py
+++ b/src/pds_doi_service/core/outputs/datacite/datacite_validator.py
@@ -12,6 +12,7 @@ datacite_validator.py
 Contains functions for validating the contents of DataCite JSON labels.
 """
 import json
+from importlib import resources
 from os.path import exists
 
 import jsonschema
@@ -19,7 +20,6 @@ from distutils.util import strtobool
 from pds_doi_service.core.entities.exceptions import InputFormatException
 from pds_doi_service.core.outputs.service_validator import DOIServiceValidator
 from pds_doi_service.core.util.general_util import get_logger
-from pkg_resources import resource_filename
 
 logger = get_logger(__name__)
 
@@ -33,7 +33,7 @@ class DOIDataCiteValidator(DOIServiceValidator):
     def __init__(self):
         super().__init__()
 
-        schema_file = resource_filename(__name__, "datacite_4.3_schema.json")
+        schema_file = str(resources.files(__name__) / "datacite_4.3_schema.json")
 
         if not exists(schema_file):
             raise RuntimeError(

--- a/src/pds_doi_service/core/outputs/doi_validator.py
+++ b/src/pds_doi_service/core/outputs/doi_validator.py
@@ -123,7 +123,7 @@ class DOIValidator:
                 # the status is greater than or equal to 400.
                 if status_code >= 400:
                     # Need to check its an 404, 503, 500, 403 etc.
-                    raise requests.HTTPError(f"status_code,site_url {status_code,doi.site_url}")
+                    raise requests.HTTPError(f"status_code,site_url {status_code, doi.site_url}")
                 else:
                     logger.info("Landing page URL %s is reachable", doi.site_url)
             except (requests.exceptions.ConnectionError, Exception):

--- a/src/pds_doi_service/core/outputs/osti/osti_record.py
+++ b/src/pds_doi_service/core/outputs/osti/osti_record.py
@@ -13,6 +13,7 @@ Contains classes used to create OSTI-compatible labels from Doi objects in memor
 """
 import html
 from datetime import datetime
+from importlib import resources
 from os.path import exists
 
 import jinja2
@@ -23,7 +24,6 @@ from pds_doi_service.core.outputs.doi_record import DOIRecord
 from pds_doi_service.core.outputs.doi_record import VALID_CONTENT_TYPES
 from pds_doi_service.core.util.general_util import get_logger
 from pds_doi_service.core.util.general_util import sanitize_json_string
-from pkg_resources import resource_filename
 
 logger = get_logger(__name__)
 
@@ -39,8 +39,8 @@ class DOIOstiRecord(DOIRecord):
     def __init__(self):
         """Creates a new DOIOstiRecord instance"""
         # Need to find the m̵u̵s̵t̵a̵c̵h̵e̵ Jinja2 DOI templates
-        self._xml_template_path = resource_filename(__name__, "DOI_IAD2_template_20210914-jinja2.xml")
-        self._json_template_path = resource_filename(__name__, "DOI_IAD2_template_20210914-jinja2.json")
+        self._xml_template_path = str(resources.files(__name__) / "DOI_IAD2_template_20210914-jinja2.xml")
+        self._json_template_path = str(resources.files(__name__) / "DOI_IAD2_template_20210914-jinja2.json")
 
         if not exists(self._xml_template_path) or not exists(self._json_template_path):
             raise RuntimeError(

--- a/src/pds_doi_service/core/outputs/osti/osti_validator.py
+++ b/src/pds_doi_service/core/outputs/osti/osti_validator.py
@@ -12,6 +12,7 @@ osti_validator.py
 Contains functions for validating the contents of OSTI XML labels.
 """
 import tempfile
+from importlib import resources
 from os.path import exists
 
 import xmlschema  # type: ignore
@@ -22,7 +23,6 @@ from pds_doi_service.core.entities.doi import DoiStatus
 from pds_doi_service.core.entities.exceptions import InputFormatException
 from pds_doi_service.core.outputs.service_validator import DOIServiceValidator
 from pds_doi_service.core.util.general_util import get_logger
-from pkg_resources import resource_filename
 
 # Note that in the ↑ list of imports, the ``lxml`` module does have the ``isoschematron``
 # member, but the typing stub does not so set just it to ``type: ignore``.
@@ -40,7 +40,7 @@ class DOIOstiValidator(DOIServiceValidator):
     def __init__(self):
         super().__init__()
 
-        schematron_file = resource_filename(__name__, "IAD3_schematron.sch")
+        schematron_file = str(resources.files(__name__) / "IAD3_schematron.sch")
 
         if not exists(schematron_file):
             raise RuntimeError(
@@ -51,7 +51,7 @@ class DOIOstiValidator(DOIServiceValidator):
         sct_doc = etree.parse(schematron_file)
         self._schematron = isoschematron.Schematron(sct_doc, store_report=True)
 
-        xsd_filename = resource_filename(__name__, "iad_schema.xsd")
+        xsd_filename = str(resources.files(__name__) / "iad_schema.xsd")
 
         if not exists(xsd_filename):
             raise RuntimeError(

--- a/src/pds_doi_service/core/outputs/test/datacite_test.py
+++ b/src/pds_doi_service/core/outputs/test/datacite_test.py
@@ -2,6 +2,7 @@
 import json
 import unittest
 from datetime import datetime
+from importlib import resources
 from os.path import abspath
 from os.path import join
 from unittest.mock import patch
@@ -21,7 +22,6 @@ from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_JSON
 from pds_doi_service.core.outputs.web_client import WEB_METHOD_POST
 from pds_doi_service.core.outputs.web_client import WEB_METHOD_PUT
 from pds_doi_service.core.util.config_parser import DOIConfigUtil
-from pkg_resources import resource_filename
 from requests.models import Response
 
 
@@ -30,7 +30,7 @@ class DOIDataCiteRecordTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__))
         cls.input_dir = abspath(join(cls.test_dir, "data"))
 
     def test_create_datacite_label_json(self):
@@ -134,7 +134,7 @@ class DOIDataCiteWebClientTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__))
         cls.input_dir = abspath(join(cls.test_dir, "data"))
 
     @patch.object(requests, "request", requests_valid_request_patch)
@@ -257,7 +257,7 @@ class DOIDataCiteWebParserTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__))
         cls.input_dir = abspath(join(cls.test_dir, "data"))
 
         cls.expected_authors = [
@@ -474,7 +474,7 @@ class DOIDataCiteValidatorTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__))
         cls.input_dir = abspath(join(cls.test_dir, "data"))
 
     def test_json_label_validation(self):

--- a/src/pds_doi_service/core/outputs/test/doi_validator_test.py
+++ b/src/pds_doi_service/core/outputs/test/doi_validator_test.py
@@ -310,7 +310,7 @@ class DoiValidatorTest(unittest.TestCase):
 
         # Test max valid identifier length
         partial_id = "urn:nasa:pds:lab_shocked_feldspars"
-        doi_obj.pds_identifier = f"{partial_id}{'a'*(255 - len(partial_id))}"
+        doi_obj.pds_identifier = f"{partial_id}{'a' * (255 - len(partial_id))}"
 
         self._doi_validator._check_lidvid_field(doi_obj)
 
@@ -375,7 +375,7 @@ class DoiValidatorTest(unittest.TestCase):
 
         # Test invalid identifier length
         partial_id = "urn:nasa:pds:lab_shocked_feldspars"
-        doi_obj.pds_identifier = f"{partial_id}{'a'*(256 - len(partial_id))}"
+        doi_obj.pds_identifier = f"{partial_id}{'a' * (256 - len(partial_id))}"
 
         with self.assertRaises(InvalidIdentifierException):
             self._doi_validator._check_lidvid_field(doi_obj)

--- a/src/pds_doi_service/core/outputs/test/osti_test.py
+++ b/src/pds_doi_service/core/outputs/test/osti_test.py
@@ -2,6 +2,7 @@
 import json
 import unittest
 from datetime import datetime
+from importlib import resources
 from os.path import abspath
 from os.path import join
 
@@ -12,7 +13,6 @@ from pds_doi_service.core.outputs.doi_record import CONTENT_TYPE_XML
 from pds_doi_service.core.outputs.osti.osti_record import DOIOstiRecord
 from pds_doi_service.core.outputs.osti.osti_web_parser import DOIOstiJsonWebParser
 from pds_doi_service.core.outputs.osti.osti_web_parser import DOIOstiXmlWebParser
-from pkg_resources import resource_filename
 
 
 class DOIOstiRecordTestCase(unittest.TestCase):
@@ -20,7 +20,7 @@ class DOIOstiRecordTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__))
         cls.input_dir = abspath(join(cls.test_dir, "data"))
 
     def test_create_osti_label_xml(self):
@@ -78,7 +78,7 @@ class DOIOstiWebParserTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__))
         cls.input_dir = abspath(join(cls.test_dir, "data"))
 
         cls.expected_authors = [

--- a/src/pds_doi_service/core/util/config_parser.py
+++ b/src/pds_doi_service/core/util/config_parser.py
@@ -16,12 +16,12 @@ import configparser
 import functools
 import os
 import sys
+from importlib import resources
 from os.path import abspath
 from os.path import dirname
 from os.path import join
 
 from pds_doi_service.core.util.logging import get_logger
-from pkg_resources import resource_filename
 
 logger = get_logger()
 
@@ -77,7 +77,7 @@ class DOIConfigUtil:
     @staticmethod
     def get_config_defaults_filepath():
         """Return the expected path of the user-specified configuration"""
-        return resource_filename(__name__, "conf.default.ini")
+        return str(resources.files(__name__) / "conf.default.ini")
 
     @staticmethod
     def _resolve_relative_path(parser):

--- a/src/pds_doi_service/core/util/doi_xml_differ.py
+++ b/src/pds_doi_service/core/util/doi_xml_differ.py
@@ -99,14 +99,14 @@ class DOIDiffer:
                             )
                             for kk in range(len(space_split_historical_tokens)):
                                 logger.debug(
-                                    f"KEYWORD_SEARCH_FAILED:INSPECTING_IN {space_split_historical_tokens[kk]} IN {new_value_tokens[jj],space_split_historical_tokens[kk] in new_value_tokens[jj]}"
+                                    f"KEYWORD_SEARCH_FAILED:INSPECTING_IN {space_split_historical_tokens[kk]} IN {new_value_tokens[jj], space_split_historical_tokens[kk] in new_value_tokens[jj]}"
                                 )
                                 if space_split_historical_tokens[kk] in new_value_tokens[jj]:
                                     o_difference_is_acceptable_flag = True
                                 else:
                                     pass
                                     logger.debug(
-                                        f"KEYWORD_SEARCH_FAILED:historical_value_tokens[ii] NOT_IN new_value_tokens[jj] {historical_value_tokens[ii],new_value_tokens[jj]}"
+                                        f"KEYWORD_SEARCH_FAILED:historical_value_tokens[ii] NOT_IN new_value_tokens[jj] {historical_value_tokens[ii], new_value_tokens[jj]}"
                                     )
                     if not o_difference_is_acceptable_flag:
                         logger.error(
@@ -171,11 +171,11 @@ class DOIDiffer:
                 if historical_token.lower() in sanitized_new_value:
                     num_tokens_compared += 1
                 logger.debug(
-                    f"FULL_NAME:historical_token,sanitized_new_value,o_difference_is_acceptable_flag {historical_token,sanitized_new_value,o_difference_is_acceptable_flag}"
+                    f"FULL_NAME:historical_token,sanitized_new_value,o_difference_is_acceptable_flag {historical_token, sanitized_new_value, o_difference_is_acceptable_flag}"
                 )
 
             logger.debug(
-                f"FULL_NAME:historical_value,sanitized_new_value,o_difference_is_acceptable_flag {historical_value,sanitized_new_value,o_difference_is_acceptable_flag,new_list_to_skip_compare,num_tokens_compared,len(historical_value_tokens)}"
+                f"FULL_NAME:historical_value,sanitized_new_value,o_difference_is_acceptable_flag {historical_value, sanitized_new_value, o_difference_is_acceptable_flag, new_list_to_skip_compare, num_tokens_compared, len(historical_value_tokens)}"
             )
             # If all tokens from historical_value can be found in new_value then we are successful.
             if num_tokens_compared == len(historical_value_tokens):
@@ -264,7 +264,7 @@ class DOIDiffer:
         if child_level_1.tag == "date_record_added":
             pass
 
-        logger.debug(f"FINAL_TAG {o_xpath_tag,original_tag,levels_travelled_up}")
+        logger.debug(f"FINAL_TAG {o_xpath_tag, original_tag, levels_travelled_up}")
 
         return o_xpath_tag
 
@@ -304,17 +304,17 @@ class DOIDiffer:
 
             # Because some fields are forced to exist eventhough it is an empty string, check for None-ness otherwise
             # the lstrip() will failed on None.  e.g <id> </id>
-            logger.info(f"child_level_1.tag,field_index,len(new_child) {child_level_1.tag,field_index,len(new_child)}")
+            logger.info(f"child_level_1.tag,field_index,len(new_child) {child_level_1.tag, field_index, len(new_child)}")
             if new_child[field_index].text is not None:
                 if child_level_1.text.lstrip().rstrip() == new_child[field_index].text.lstrip().rstrip():
                     pass  # Field is the same which is good.
                     logger.debug(
-                        f"FIELD_SAME_TRUE: {child_level_1,child_level_1.text} == {new_child[field_index].text}"
+                        f"FIELD_SAME_TRUE: {child_level_1, child_level_1.text} == {new_child[field_index].text}"
                     )
                 else:
                     # Fields are different.  Attempt to resolve the apparent differences.
                     logger.debug(
-                        f"FIELD_SAME_FALSE: {child_level_1,child_level_1.text} != {new_child[field_index].text}"
+                        f"FIELD_SAME_FALSE: {child_level_1, child_level_1.text} != {new_child[field_index].text}"
                     )
 
                     # It is possible for new_child[0].text to be None so do not perform lstrip() and rstrip()
@@ -328,11 +328,11 @@ class DOIDiffer:
                         # Save the values different.
                         o_values_differ = "historical:[" + child_level_1.text + "], new:[" + new_child[0].text + "]"
                         logger.info(
-                            f"FIELD_SAME_FALSE_FINALLY: {child_level_1,child_level_1.text} != {new_child[field_index].text}"
+                            f"FIELD_SAME_FALSE_FINALLY: {child_level_1, child_level_1.text} != {new_child[field_index].text}"
                         )
                     else:
                         logger.info(
-                            f"FIELD_SAME_TRUE_FINALLY: {child_level_1,child_level_1.text} == {new_child[field_index].text}"
+                            f"FIELD_SAME_TRUE_FINALLY: {child_level_1, child_level_1.text} == {new_child[field_index].text}"
                         )
 
         return o_field_differ_name, o_values_differ
@@ -425,7 +425,7 @@ class DOIDiffer:
 
         indices_where_field_occur_dict = DOIDiffer._setup_where_field_occur_dict()
 
-        logger.info(f"element_index,historical_element.tag {element_index,historical_element.tag}")
+        logger.info(f"element_index,historical_element.tag {element_index, historical_element.tag}")
         # Get the same 'record' element from the new_doc XML tree.  Assumes the ordering is the same.
         new_element = new_doc.xpath(historical_element.tag)[element_index]
 
@@ -529,7 +529,7 @@ class DOIDiffer:
                 element_index += 1
                 records_compared += 1
 
-        logger.debug(f"records_compared {records_compared,historical_xml_output,new_xml_output}")
+        logger.debug(f"records_compared {records_compared, historical_xml_output, new_xml_output}")
 
         return o_fields_differ_list, o_values_differ_list, o_record_index_differ_list
 

--- a/src/pds_doi_service/core/util/test/config_parser_test.py
+++ b/src/pds_doi_service/core/util/test/config_parser_test.py
@@ -2,11 +2,11 @@
 import os
 import sys
 import unittest
+from importlib import resources
 
 from pds_doi_service.core.util import config_parser
 from pds_doi_service.core.util.config_parser import DOIConfigParser
 from pds_doi_service.core.util.config_parser import DOIConfigUtil
-from pkg_resources import resource_filename
 
 
 class ConfigParserTest(unittest.TestCase):
@@ -27,7 +27,7 @@ class ConfigParserTest(unittest.TestCase):
         parser = DOIConfigParser()
 
         # Populate our config parser with the default INI
-        conf_file_path = resource_filename("pds_doi_service", "core/util/conf.default.ini")
+        conf_file_path = str(resources.files("pds_doi_service.core.util") / "conf.default.ini")
         parser.read(conf_file_path)
 
         # Ensure we get values from the default INI to begin with

--- a/src/pds_doi_service/notebooks/Bulk Record Update.ipynb
+++ b/src/pds_doi_service/notebooks/Bulk Record Update.ipynb
@@ -388,7 +388,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, docs, lint
+envlist = py313, docs, lint
 isolated_build = True
 
 [testenv]
@@ -14,7 +14,7 @@ passenv =
 [testenv:docs]
 deps = .[dev]
 whitelist_externals = python
-commands = python setup.py build_sphinx
+commands = sphinx-build -b html docs/source docs/build
 
 [testenv:lint]
 deps = pre-commit
@@ -23,6 +23,6 @@ commands=
 skip_install = true
 
 [testenv:dev]
-basepython = python3.9
+basepython = python3.13
 usedevelop = True
 deps = .[dev]


### PR DESCRIPTION
## 🗒️ Summary

Upgrades for Python 3.13; specifically:

- Branch CICD and CodeQL workflows now use Python 3.13
- Harmonized secrets detection between pre-commit and GitHub Actions workflow
- Disabled "black" due to its conflict with reorder-python-imports
- Updated README.md and the "Bulk Record Update" notebook to reflect the new Python version
- Modernized Sphinx docs settings for new Sphinx version and updated "Installation" section
- Removed license from Trove classifiers
- Updated dependencies for Python 3.13
- `smptd` was removed in Python 3.12, so substituted with `aiosmtpd` and adjusted message parsing to account for the change
- Replaced numerous—and I mean _numerous_—`pkg_resources` with `importlib`
- Updated `tox.ini` for Python 3.13


## ⚙️ Test Data and/or Report


Commands:
```
$ pds-doi-cmd --help
…
Usage for each subcommand is available by providing the --help argument to the subcommand:
    pds-doi-cmd reserve --help
$ pds-doi-api
…
WARNING connexion.options:openapi_console_ui_available The swagger_ui directory could not be found.
…
INFO pds_doi_service.api.__main__:main Waitress logging configured at level DEBUG
INFO waitress:log_info Serving on http://0.0.0.0:8080
^C
$ pds-doi-init --help
…
Note: When DOI records are imported to the local transaction database, the DOI service creates an associated output
label for each record under the transaction_history directory. The format of this output label is driven by the
SERVICE.provider field of the INI. Please ensure the field is set appropriately before using this script, as a
mismatch could cause parsing errors when using the DOI service after this script.
```

Tox:
```
docs: OK ✔ in 2.16 seconds
lint: commands[0]> python -m pre_commit run --color=always --all
[WARNING] hook id `tests` uses deprecated stage names (push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check that executables have shebangs.....................................Passed
Check for merge conflicts................................................Passed
Debug Statements (Python)................................................Passed
Check Yaml...............................................................Passed
Reorder python imports...................................................Passed
flake8...................................................................Passed
Detect secrets...........................................................Passed
  py313: OK (11.91=setup[2.50]+cmd[9.40] seconds)
  docs: OK (2.16=setup[1.77]+cmd[0.39] seconds)
  lint: OK (2.84=setup[0.00]+cmd[2.83] seconds)
  congratulations :) (16.97 seconds)
```

## ♻️ Related Issues

- https://github.com/NASA-PDS/template-repo-python/issues/105