### PR TITLE
Update_datacite_jinja2_template

### DIFF
--- a/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
+++ b/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
@@ -26,7 +26,7 @@
                     {
                         "identifier": "{{ identifier.identifier.strip() }}",
                         "identifierType": "{{ identifier.identifierType }}"
-                    }{% if not loop.last %},{% endif %}
+                    }{% if not loop.last %},{% endif +%}
                     {% endfor %}
                 ],
                 "creators": [
@@ -36,7 +36,7 @@
                         "nameType": "{{author.name_type}}",
                         {% else %}
                         "nameType": "Personal",
-                        {%- endif %}
+                        {% endif %}
                         {% if author.first_name and author.last_name %}
                         "name": "{{ author.first_name }} {{ author.last_name }}",
                         {% else %}
@@ -45,7 +45,7 @@
                         {% if author.affiliation and author.affiliation|length > 0 %}
                         "affiliation": [
                         {% for affiliation in author.affiliation %}
-                            "{{affiliation}}"{% if not loop.last %},{% endif %}
+                            "{{affiliation}}"{% if not loop.last %},{% endif +%}
                         {% endfor %}
                         ],
                         {% endif %}
@@ -67,12 +67,12 @@
                         {% for name_identifier in author.name_identifiers %}
                             {
                             {% for key, value in name_identifier.items() %}
-                                "{{key}}": "{{value}}"{% if not loop.last %},{% endif %}
+                                "{{key}}": "{{value}}"{% if not loop.last %},{% endif +%}
                             {% endfor %}
                             }
                         {% endfor %}
                         ]
-                    }{% if not loop.last %},{% endif %}
+                    }{% if not loop.last %},{% endif +%}
                     {% endfor %}
                 ],
                 "titles": [
@@ -85,12 +85,12 @@
                 "publicationYear": "{{ doi.publication_year }}",
                 "rightsList": [
                     {% for rights_element in doi.rights_list %}
-                    {{ rights_element }}{% if not loop.last %},{% endif %}
+                    {{ rights_element }}{% if not loop.last %},{% endif +%}
                     {% endfor %}
                 ],
                 "subjects": [
                     {% for keyword in doi.keywords %}
-                    { "subject": "{{ keyword }}" }{% if not loop.last %},{% endif %}
+                    { "subject": "{{ keyword }}" }{% if not loop.last %},{% endif +%}
                     {% endfor %}
                 ],
                 "contributors": [
@@ -125,11 +125,13 @@
                             }
                         {% endfor %}
                         ],
-                        "affiliations": [
-                            {% if editor.affiliation %}
-                                 { "affiliation": "{{editor.affiliation}}" }
-                            {% endif %}
+                        {% if editor.affiliation and editor.affiliation|length > 0 %}
+                        "affiliation": [
+                            {% for affiliation in editor.affiliation %}
+                                "{{affiliation}}"{% if not loop.last %},{% endif +%}
+                            {% endfor %}
                         ],
+                        {% endif %}
                         "contributorType": "Editor"
                     },
                     {% endfor %}


### PR DESCRIPTION
Added formatting constraints (+/-) for line endings to the jinja2 template.

src\pds_doi_service\core\outputs\datacite\DOI_DataCite_template_20210520-jinja2.json

The + and - characters in Jinja2 are whitespace control modifiers that help you manage how whitespace is handled in your template output.

The - character removes whitespace around template tags:
The + character preserves whitespace around template tags, even when it would normally be stripped:

<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Added formatting constraints (+/-) for line endings.

## ⚙️ Test Data and/or Report
One of the following should be included here:
* Reference to regression test included in code (preferred wherever reasonable)
* Attach test data here + outputs of tests

See: src\pds_doi_service\core\outputs\datacite\DOI_DataCite_template_20210520-jinja2.json


## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
None

