### PR TITLE
Add Affiliation, LBLX, ROR, ORCID functions

### DIFF
--- a/src/pds_doi_service/core/input/test/data/datacite_record_draft.json
+++ b/src/pds_doi_service/core/input/test/data/datacite_record_draft.json
@@ -19,7 +19,7 @@
                     "name": "Deen, R.",
                     "givenName": "R.",
                     "familyName": "Deen",
-                    "affiliation": ["NASA PDS"],
+                    "affiliation": [{"name": "NASA PDS"}],
                     "nameIdentifiers": []
                 },
                 {
@@ -27,7 +27,7 @@
                     "name": "Abarca, H.",
                     "givenName": "H.",
                     "familyName": "Abarca",
-                    "affiliation": ["NASA PDS"],
+                    "affiliation": [{"name": "NASA PDS"}],
                     "nameIdentifiers": []
                 },
                 {
@@ -35,7 +35,7 @@
                     "name": "Zamani, P.",
                     "givenName": "P.",
                     "familyName": "Zamani",
-                    "affiliation": ["NASA PDS"],
+                    "affiliation": [{"name": "NASA PDS"}],
                     "nameIdentifiers": []
                 },
                 {
@@ -43,7 +43,7 @@
                     "name": "Maki, J.",
                     "givenName": "J.",
                     "familyName": "Maki",
-                    "affiliation": ["NASA PDS"],
+                    "affiliation": [{"name": "NASA PDS"}],
                     "nameIdentifiers": []
                 }
             ],
@@ -118,7 +118,7 @@
                     "givenName": "P. H.",
                     "familyName": "Smith",
                     "contributorType": "Editor",
-                    "affiliation": ["NASA PDS"],
+                    "affiliation": [{"name": "NASA PDS"}],
                     "nameIdentifiers": []
                 },
                 {
@@ -127,7 +127,7 @@
                     "givenName": "M.",
                     "familyName": "Lemmon",
                     "contributorType": "Editor",
-                    "affiliation": ["NASA PDS"],
+                    "affiliation": [{"name": "NASA PDS"}],
                     "nameIdentifiers": []
                 },
                 {
@@ -136,14 +136,14 @@
                     "givenName": "R. F.",
                     "familyName": "Beebe",
                     "contributorType": "Editor",
-                    "affiliation": ["NASA PDS"],
+                    "affiliation": [{"name": "NASA PDS"}],
                     "nameIdentifiers": []
                 },
                 {
                     "nameType": "Organizational",
                     "name": "Planetary Data System: Engineering Node",
                     "contributorType": "DataCurator",
-                    "affiliation": ["NASA PDS"],
+                    "affiliation": [{"name": "NASA PDS"}],
                     "nameIdentifiers": []
                 }
             ],

--- a/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
+++ b/src/pds_doi_service/core/outputs/datacite/DOI_DataCite_template_20210520-jinja2.json
@@ -44,32 +44,30 @@
                         {% endif %}
                         {% if author.affiliation and author.affiliation|length > 0 %}
                         "affiliation": [
-                        {% for affiliation in author.affiliation %}
-                            "{{affiliation}}"{% if not loop.last %},{% endif %}
-                        {% endfor %}
+                            {% for affiliation in author.affiliation %}
+                                {"name": "{{affiliation}}" }{% if not loop.last %},{% endif +%}
+                            {% endfor %}
                         ],
                         {% endif %}
                         "nameIdentifiers": [
-                        {%- if author.rorid %}
-                            {
-                                "nameIdentifier": "{{ author.rorid }}",
+                        {% if author.rorid %}
+                            {   "nameIdentifier": "{{ author.rorid }}",
                                 "nameIdentifierScheme": "ROR",
                                 "schemeUri": "https://ror.org"
-                            }{%- if author.orcid or author.name_identifiers %},{%- endif %}
-                        {%- endif %}
-                        {%- if author.orcid %}
+                            }{% if author.orcid or author.name_identifiers %},{% endif %}
+                        {% elif author.orcid %}
                             {
                                 "nameIdentifier": "{{ author.orcid }}",
                                 "nameIdentifierScheme": "ORCID",
                                 "schemeUri": "https://orcid.org"
-                            }
-                        {%- endif %}
+                            }{% if author.name_identifiers %},{% endif %}
+                        {% endif %}
                         {% for name_identifier in author.name_identifiers %}
                             {
                             {% for key, value in name_identifier.items() %}
                                 "{{key}}": "{{value}}"{% if not loop.last %},{% endif %}
                             {% endfor %}
-                            }
+                            }{% if not loop.last %},{% endif %}
                         {% endfor %}
                         ]
                     }{% if not loop.last %},{% endif %}
@@ -90,7 +88,7 @@
                 ],
                 "subjects": [
                     {% for keyword in doi.keywords %}
-                    { "subject": "{{ keyword }}" }{% if not loop.last %},{% endif %}
+                    { "subject": "{{ keyword }}" }{% if not loop.last %},{% endif +%}
                     {% endfor %}
                 ],
                 "contributors": [
@@ -103,33 +101,34 @@
                         "name": "{{ editor.name }}",
                         {% endif %}
                         "nameIdentifiers": [
-                        {%- if editor.rorid %}
+                        {% if editor.rorid %}
                             {
                                 "nameIdentifier": "{{ editor.rorid }}",
                                 "nameIdentifierScheme": "ROR",
                                 "schemeUri": "https://ror.org"
-                            }{%- if editor.orcid or editor.name_identifiers %},{%- endif %}
-                        {%- endif %}
-                        {%- if editor.orcid %}
+                            }{% if editor.orcid or editor.name_identifiers %},{% endif %}
+                        {% elif editor.orcid %}
                             {
                                 "nameIdentifier": "{{ editor.orcid }}",
                                 "nameIdentifierScheme": "ORCID",
                                 "schemeUri": "https://orcid.org"
-                            }
+                            }{% if editor.name_identifiers %},{% endif %}
                         {% endif %}
                         {% for name_identifier in editor.name_identifiers %}
                             {
                             {% for key, value in name_identifier.items() %}
                                 "{{key}}": "{{value}}"{% if not loop.last %},{% endif %}
                             {% endfor %}
-                            }
+                            }{% if not loop.last %},{% endif %}
                         {% endfor %}
                         ],
-                        "affiliations": [
-                            {% if editor.affiliation %}
-                                 { "affiliation": "{{editor.affiliation}}" }
-                            {% endif %}
+                        {% if editor.affiliation and editor.affiliation|length > 0 %}
+                        "affiliation": [
+                            {% for affiliation in editor.affiliation %}
+                                {"name": "{{affiliation}}" }{% if not loop.last %},{% endif +%}
+                            {% endfor %}
                         ],
+                        {% endif %}
                         "contributorType": "Editor"
                     },
                     {% endfor %}

--- a/src/pds_doi_service/core/outputs/datacite/datacite_4.6_schema.json
+++ b/src/pds_doi_service/core/outputs/datacite/datacite_4.6_schema.json
@@ -1,0 +1,492 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+
+    "definitions": {
+        "nameType": {
+            "type": "string",
+            "enum": [
+                "Organizational",
+                "Personal"
+            ]
+        },
+        "nameIdentifiers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "nameIdentifier": {"type": "string"},
+                    "nameIdentifierScheme": {"type": "string"},
+                    "schemeURI": {"type": "string", "format": "uri"}
+                },
+                "required": ["nameIdentifier", "nameIdentifierScheme"]
+            },
+            "uniqueItems": true
+        },
+        "affiliation": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "affiliationIdentifier": { "type": "string" },
+                    "affiliationIdentifierScheme": { "type": "string" },
+                    "schemeUri": { "type": "string", "format": "uri" }
+                },
+                "required": ["name"]
+            }
+        },
+        "titleType": {
+            "type": "string",
+            "enum": [
+                "AlternativeTitle",
+                "Subtitle",
+                "TranslatedTitle",
+                "Other"
+            ]
+        },
+        "contributorType": {
+            "type": "string",
+            "enum": [
+                "ContactPerson",
+                "DataCollector",
+                "DataCurator",
+                "DataManager",
+                "Distributor",
+                "Editor",
+                "HostingInstitution",
+                "Producer",
+                "ProjectLeader",
+                "ProjectManager",
+                "ProjectMember",
+                "RegistrationAgency",
+                "RegistrationAuthority",
+                "RelatedPerson",
+                "Researcher",
+                "ResearchGroup",
+                "RightsHolder",
+                "Sponsor",
+                "Supervisor",
+                "WorkPackageLeader",
+                "Other"
+            ]
+        },
+        "date": {
+            "type": "string",
+            "anyOf": [
+                {"format": "year"},
+                {"format": "yearmonth"},
+                {"format": "date"},
+                {"format": "datetime"},
+                {"format": "year-range"},
+                {"format": "yearmonth-range"},
+                {"format": "date-range"},
+                {"format": "datetime-range"}
+            ]
+        },
+        "dateType": {
+            "type": "string",
+            "enum": [
+                "Accepted",
+                "Available",
+                "Copyrighted",
+                "Collected",
+                "Created",
+                "Issued",
+                "Submitted",
+                "Updated",
+                "Valid",
+                "Withdrawn",
+                "Other"
+            ]
+        },
+        "resourceTypeGeneral": {
+            "type": "string",
+            "enum": [
+                "Audiovisual",
+                "Collection",
+                "DataPaper",
+                "Dataset",
+                "Event",
+                "Image",
+                "InteractiveResource",
+                "Model",
+                "PhysicalObject",
+                "Service",
+                "Software",
+                "Sound",
+                "Text",
+                "Workflow",
+                "Other"
+            ]
+        },
+        "relatedIdentifierType": {
+            "type": "string",
+            "enum": [
+                "ARK",
+                "arXiv",
+                "bibcode",
+                "DOI",
+                "EAN13",
+                "EISSN",
+                "Handle",
+                "IGSN",
+                "ISBN",
+                "ISSN",
+                "ISTC",
+                "LISSN",
+                "LSID",
+                "PMID",
+                "PURL",
+                "UPC",
+                "URL",
+                "URN",
+                "w3id"
+            ]
+        },
+        "relationType": {
+            "type": "string",
+            "enum": [
+                "IsCitedBy",
+                "Cites",
+                "IsSupplementTo",
+                "IsSupplementedBy",
+                "IsContinuedBy",
+                "Continues",
+                "IsDescribedBy",
+                "Describes",
+                "HasMetadata",
+                "IsMetadataFor",
+                "HasVersion",
+                "IsVersionOf",
+                "IsNewVersionOf",
+                "IsPreviousVersionOf",
+                "IsPartOf",
+                "HasPart",
+                "IsReferencedBy",
+                "References",
+                "IsDocumentedBy",
+                "Documents",
+                "IsCompiledBy",
+                "Compiles",
+                "IsVariantFormOf",
+                "IsOriginalFormOf",
+                "IsIdenticalTo",
+                "IsReviewedBy",
+                "Reviews",
+                "IsDerivedFrom",
+                "IsSourceOf",
+                "IsRequiredBy",
+                "Requires",
+                "IsObsoletedBy",
+                "Obsoletes"
+            ]
+        },
+        "descriptionType": {
+            "type": "string",
+            "enum": [
+                "Abstract",
+                "Methods",
+                "SeriesInformation",
+                "TableOfContents",
+                "TechnicalInfo",
+                "Other"
+            ]
+        },
+        "geoLocationPoint": {
+            "type": "object",
+            "properties": {
+                "pointLongitude": {"$ref": "#/definitions/longitude"},
+                "pointLatitude": {"$ref": "#/definitions/latitude"}
+            },
+            "required": ["pointLongitude", "pointLatitude"]
+        },
+        "longitude": {
+            "type": "number",
+            "minimum": -180,
+            "maximum": 180
+        },
+        "latitude": {
+            "type": "number",
+            "minimum": -90,
+            "maximum": 90
+        },
+        "funderIdentifierType": {
+            "type": "string",
+            "enum": [
+                "ISNI",
+                "GRID",
+                "Crossref Funder ID",
+                "Other"
+            ]
+        }
+    },
+
+    "type": "object",
+
+    "properties": {
+        "types": {
+            "type": "object",
+            "properties": {
+                "resourceType": {"type": "string"},
+                "resourceTypeGeneral": {"$ref": "#/definitions/resourceTypeGeneral"}
+            },
+            "required": ["resourceType", "resourceTypeGeneral"]
+        },
+        "identifiers": {
+            "type": "array",
+            "items":{
+                "type": "object",
+                "properties": {
+                    "identifier": {"type": "string"},
+                    "identifierType": {"type": "string"}
+                },
+                "required": ["identifier", "identifierType"]
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "creators": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "nameType": {"$ref": "#/definitions/nameType"},
+                    "givenName": {"type": "string"},
+                    "familyName": {"type": "string"},
+                    "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
+                    "affiliation": {"$ref": "#/definitions/affiliation"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["name"]
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "titles": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "titleType": {"$ref": "#/definitions/titleType"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["title"]
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "publisher": {
+            "type": "string"
+        },
+        "publicationYear": {
+            "type": "string",
+            "format": "year"
+        },
+        "subjects": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "subject": {"type": "string"},
+                    "subjectScheme": {"type": "string"},
+                    "schemeURI": {"type": "string", "format": "uri"},
+                    "valueURI": {"type": "string", "format": "uri"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["subject"]
+            },
+            "uniqueItems": true
+        },
+        "contributors": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "contributorType": {"$ref": "#/definitions/contributorType"},
+                    "name": {"type": "string"},
+                    "nameType": {"$ref": "#/definitions/nameType"},
+                    "givenName": {"type": "string"},
+                    "familyName": {"type": "string"},
+                    "nameIdentifiers": {"$ref": "#/definitions/nameIdentifiers"},
+                    "affiliation": {"$ref": "#/definitions/affiliation"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["contributorType", "name"]
+            },
+            "uniqueItems": true
+        },
+        "dates": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "date": {"$ref": "#/definitions/date"},
+                    "dateType": {"$ref": "#/definitions/dateType"},
+                    "dateInformation": {"type": "string"}
+                },
+                "required": ["date", "dateType"]
+            },
+            "uniqueItems": true
+        },
+        "language": {
+            "type": "string",
+            "$comment": "Primary language of the resource. Allowed values are taken from  IETF BCP 47, ISO 639-1 language codes."
+        },
+        "alternateIdentifiers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "alternateIdentifier": {"type": "string"},
+                    "alternateIdentifierType": {"type": "string"}
+                },
+                "required": ["alternateIdentifier", "alternateIdentifierType"]
+            },
+            "uniqueItems": true
+        },
+        "relatedIdentifiers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "relatedIdentifier": {"type": "string"},
+                    "relatedIdentifierType": {"$ref": "#/definitions/relatedIdentifierType"},
+                    "relationType": {"$ref": "#/definitions/relationType"},
+                    "relatedMetadataScheme": {"type": "string"},
+                    "schemeURI": {"type": "string", "format": "uri"},
+                    "schemeType": {"type": "string"},
+                    "resourceTypeGeneral": {"$ref": "#/definitions/resourceTypeGeneral"}
+                },
+                "required": ["relatedIdentifier", "relatedIdentifierType", "relationType"],
+                "if": {
+                    "properties": {
+                        "relationType": {"enum": ["HasMetadata", "IsMetadataFor"]}
+                    }
+                },
+                "else": {
+                    "$comment": "these properties may only be used with relation types HasMetadata/IsMetadataFor",
+                    "properties": {
+                        "relatedMetadataScheme": false,
+                        "schemeURI": false,
+                        "schemeType": false
+                    }
+                }
+            },
+            "uniqueItems": true
+        },
+        "sizes": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "formats": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "version": {
+            "type": "string"
+        },
+        "rightsList": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "rights": {"type": "string"},
+                    "rightsURI": {"type": "string", "format": "uri"},
+                    "rightsIdentifier": {"type": "string"},
+                    "rightsIdentifierScheme": {"type": "string"},
+                    "schemeURI": {"type": "string", "format": "uri"},
+                    "lang": {"type": "string"}
+                }
+            },
+            "uniqueItems": true
+        },
+        "descriptions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "description": {"type": "string"},
+                    "descriptionType": {"$ref": "#/definitions/descriptionType"},
+                    "lang": {"type": "string"}
+                },
+                "required": ["description", "descriptionType"]
+            },
+            "uniqueItems": true
+        },
+        "geoLocations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "geoLocationPlace": {"type": "string"},
+                    "geoLocationPoint": {"$ref": "#/definitions/geoLocationPoint"},
+                    "geoLocationBox": {
+                        "type": "object",
+                        "properties": {
+                            "westBoundLongitude": {"$ref": "#/definitions/longitude"},
+                            "eastBoundLongitude": {"$ref": "#/definitions/longitude"},
+                            "southBoundLatitude": {"$ref": "#/definitions/latitude"},
+                            "northBoundLatitude": {"$ref": "#/definitions/latitude"}
+                        },
+                        "required": ["westBoundLongitude", "eastBoundLongitude", "southBoundLatitude", "northBoundLatitude"]
+                    },
+                    "geoLocationPolygons": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "polygonPoints": {
+                                    "type": "array",
+                                    "items": {"$ref": "#/definitions/geoLocationPoint"},
+                                    "minItems": 4
+                                },
+                                "inPolygonPoint": {"$ref": "#/definitions/geoLocationPoint"}
+                            },
+                            "required": ["polygonPoints"]
+                        },
+                        "uniqueItems": true
+                    }
+                }
+            },
+            "uniqueItems": true
+        },
+        "fundingReferences": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "funderName": {"type": "string"},
+                    "funderIdentifier": {"type": "string"},
+                    "funderIdentifierType": {"$ref": "#/definitions/funderIdentifierType"},
+                    "awardNumber": {"type": "string"},
+                    "awardURI": {"type": "string", "format": "uri"},
+                    "awardTitle": {"type": "string"}
+                },
+                "required": ["funderName"]
+            },
+            "uniqueItems": true
+        },
+        "schemaVersion": {
+            "type": "string",
+            "const": "http://datacite.org/schema/kernel-4"
+        }
+    },
+
+    "required": [
+        "identifiers",
+        "creators",
+        "titles",
+        "publisher",
+        "publicationYear",
+        "types",
+        "schemaVersion"
+    ]
+}

--- a/src/pds_doi_service/core/outputs/datacite/datacite_validator.py
+++ b/src/pds_doi_service/core/outputs/datacite/datacite_validator.py
@@ -33,7 +33,12 @@ class DOIDataCiteValidator(DOIServiceValidator):
     def __init__(self):
         super().__init__()
 
-        schema_file = str(resources.files(__name__) / "datacite_4.3_schema.json")
+        # Define schema file directory and pull schema from that
+        #   -- used to ensure schema is valid JSON schema
+        #   -- updated with new versions in order to support the new schema version
+        #schema_file = str(resources.files(__name__) / "datacite_4.3_schema.json")
+        schema_file = str(resources.files(__name__) / "datacite_4.6_schema.json")
+        logger.info(f"Using datacite schema file: {schema_file}")
 
         if not exists(schema_file):
             raise RuntimeError(


### PR DESCRIPTION
Add <Affiliation> for <Person>; <Organization> doesn't not support <Affiliation> 
Add LBLX file extension for XML labels
Add , ROR, ORCID to <nameIdentifiers>

<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
        - adds capability to parse <Affiliation> for <Person> in XML labels.  
              -- Note that <Organization> doesn't not support <Affiliation> 
        - adds capability to parse XML label with LBLX file extension
        - add capability to parse ROR and ORCID as nameIdentifiers

## ⚙️ Test Data and/or Report

-- LBLX test case:
[bundle_co_rss_slepian_grav_coeff_20250723.zip](https://github.com/user-attachments/files/22780757/bundle_co_rss_slepian_grav_coeff_20250723.zip)

-- Affiliation test case:
[xml_files.zip](https://github.com/user-attachments/files/22780811/xml_files.zip)

## ♻️ Related Issues
    * for issues in this repo:
        


